### PR TITLE
CacheStats And Configuration

### DIFF
--- a/sample/EasyCaching.Demo.Providers/Controllers/ValuesController.cs
+++ b/sample/EasyCaching.Demo.Providers/Controllers/ValuesController.cs
@@ -74,5 +74,16 @@
                     return "default";
             }
         }
+
+        // GET api/values/stats
+        [HttpGet]
+        [Route("stats")]
+        public string Stats()
+        {
+            var hit = _provider.CacheStats.GetStatistic(StatsType.Hit);
+            var missed = _provider.CacheStats.GetStatistic(StatsType.Missed);
+
+            return $"hit={hit},missed={missed}";
+        }
     }
 }

--- a/sample/EasyCaching.Demo.Providers/EasyCaching.Demo.Providers.csproj
+++ b/sample/EasyCaching.Demo.Providers/EasyCaching.Demo.Providers.csproj
@@ -21,4 +21,7 @@
     <ProjectReference Include="..\..\src\EasyCaching.Serialization.MessagePack\EasyCaching.Serialization.MessagePack.csproj" />
     <ProjectReference Include="..\..\src\EasyCaching.Core\EasyCaching.Core.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Remove="easycaching.db" />
+  </ItemGroup>
 </Project>

--- a/sample/EasyCaching.Demo.Providers/Startup.cs
+++ b/sample/EasyCaching.Demo.Providers/Startup.cs
@@ -43,8 +43,10 @@
             //    option.Password = "";
             //});
 
-            ////4. Important step for using SQLite Cache
+            //4. Important step for using SQLite Cache
             //services.AddSQLiteCache(option => { });
+
+            //services.AddSQLiteCache(Configuration,option=>{});
 
             ////5. Important step for using Hybrid Cache
             ////5.1. Local Cache

--- a/sample/EasyCaching.Demo.Providers/Startup.cs
+++ b/sample/EasyCaching.Demo.Providers/Startup.cs
@@ -30,6 +30,8 @@
             //1. Important step for using InMemory Cache
             services.AddDefaultInMemoryCache(x=> { x.EnableLogging = true; });
 
+            //services.AddDefaultInMemoryCache(Configuration);
+
             ////2. Important step for using Memcached Cache
             //services.AddDefaultMemcached(op =>
             //{

--- a/sample/EasyCaching.Demo.Providers/appsettings.Development.json
+++ b/sample/EasyCaching.Demo.Providers/appsettings.Development.json
@@ -6,5 +6,8 @@
             "System": "Information",
             "Microsoft": "Information"
         }
+    },
+    "easycaching": {
+        "FileName": "my.db"
     }
 }

--- a/sample/EasyCaching.Demo.Providers/appsettings.json
+++ b/sample/EasyCaching.Demo.Providers/appsettings.json
@@ -13,6 +13,11 @@
         }
     },
     "easycaching": {
-        "FileName": "my.db"
+        "CachingProviderType": 3,
+        "MaxRdSecond": 120,
+        "Order": 2,
+        "dbconfig": {            
+            "FileName": "my.db"
+        }
     }
 }

--- a/sample/EasyCaching.Demo.Providers/appsettings.json
+++ b/sample/EasyCaching.Demo.Providers/appsettings.json
@@ -11,5 +11,8 @@
                 "Default": "Information"
             }
         }
+    },
+    "easycaching": {
+        "FileName": "my.db"
     }
 }

--- a/sample/EasyCaching.Demo.Providers/appsettings.json
+++ b/sample/EasyCaching.Demo.Providers/appsettings.json
@@ -15,9 +15,10 @@
     "easycaching": {
         "CachingProviderType": 3,
         "MaxRdSecond": 120,
-        "Order": 2,
-        "dbconfig": {            
-            "FileName": "my.db"
-        }
+        "Order": 2
+        //,
+        //"dbconfig": {            
+        //    "FileName": "my.db"
+        //}
     }
 }

--- a/sample/EasyCaching.Demo.Providers/appsettings.json
+++ b/sample/EasyCaching.Demo.Providers/appsettings.json
@@ -16,9 +16,25 @@
         "CachingProviderType": 3,
         "MaxRdSecond": 120,
         "Order": 2
-        //,
-        //"dbconfig": {            
+        ,
+        //SQLite
+        //"dbconfig": {
         //    "FileName": "my.db"
         //}
+        //Redis
+        "dbconfig": {
+            "Password": null,
+            "IsSsl": false,
+            "SslHost": null,
+            "ConnectionTimeout": 5000,
+            "AllowAdmin": true,
+            "Endpoints": [
+                {
+                    "Host": "localhost",
+                    "Port": 6739
+                }
+            ],
+            "Database": 0
+        }
     }
 }

--- a/src/EasyCaching.Core/CacheStatsCounter.cs
+++ b/src/EasyCaching.Core/CacheStatsCounter.cs
@@ -37,12 +37,12 @@
         /// Gets the hited count.
         /// </summary>
         /// <returns>The hited count.</returns>
-        public long GetHitedCount() => _hitedCount;
+        public long GetHitedCount() => Interlocked.Read(ref _hitedCount);
 
         /// <summary>
         /// Gets the missed count.
         /// </summary>
         /// <returns>The missed count.</returns>
-        public long GetMissedCount() => _missedCount;
+        public long GetMissedCount() => Interlocked.Read(ref _missedCount);
     }
 }

--- a/src/EasyCaching.Core/CacheStatsCounter.cs
+++ b/src/EasyCaching.Core/CacheStatsCounter.cs
@@ -1,0 +1,48 @@
+﻿namespace EasyCaching.Core
+{
+    using System.Threading;
+
+    /// <summary>
+    /// Cache stats counter.
+    /// </summary>
+    public class CacheStatsCounter
+    {
+        /// <summary>
+        /// The hited count.
+        /// </summary>
+        private long _hitedCount = 0;
+
+        /// <summary>
+        /// The missed count.
+        /// </summary>
+        private long _missedCount = 0;
+
+        /// <summary>
+        /// Increments the hited.
+        /// </summary>
+        public void IncrementHited()
+        {
+            Interlocked.Increment(ref _hitedCount);
+        }
+
+        /// <summary>
+        /// Increments the missed.
+        /// </summary>
+        public void IncrementMissed()
+        {
+            Interlocked.Increment(ref _missedCount);
+        }
+
+        /// <summary>
+        /// Gets the hited count.
+        /// </summary>
+        /// <returns>The hited count.</returns>
+        public long GetHitedCount() => _hitedCount;
+
+        /// <summary>
+        /// Gets the missed count.
+        /// </summary>
+        /// <returns>The missed count.</returns>
+        public long GetMissedCount() => _missedCount;
+    }
+}

--- a/src/EasyCaching.Core/EasyCachingConstValue.cs
+++ b/src/EasyCaching.Core/EasyCachingConstValue.cs
@@ -1,0 +1,18 @@
+﻿namespace EasyCaching.Core
+{
+    /// <summary>
+    /// EasyCaching const value.
+    /// </summary>
+    public class EasyCachingConstValue
+    {
+        /// <summary>
+        /// The config section.
+        /// </summary>
+        public const string ConfigSection = "easycaching";
+
+        /// <summary>
+        /// The config child section.
+        /// </summary>
+        public const string ConfigChildSection = "easycaching:dbconfig";
+    }
+}

--- a/src/EasyCaching.Core/IEasyCachingProvider.cs
+++ b/src/EasyCaching.Core/IEasyCachingProvider.cs
@@ -225,5 +225,11 @@
         /// </summary>
         /// <value>The type of the caching provider.</value>
         CachingProviderType CachingProviderType { get; }
+
+        /// <summary>
+        /// Gets or sets the cache stats.
+        /// </summary>
+        /// <value>The get stats.</value>
+        CacheStats CacheStats { get; }
     }
 }

--- a/src/EasyCaching.HybridCache/HybridCachingProvider.cs
+++ b/src/EasyCaching.HybridCache/HybridCachingProvider.cs
@@ -42,6 +42,8 @@
         /// <value>The type of the caching provider.</value>
         public CachingProviderType CachingProviderType => throw new NotImplementedException();
 
+        public CacheStats CacheStats => throw new NotImplementedException();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="T:EasyCaching.HybridCache.HybridCachingProvider"/> class.
         /// </summary>

--- a/src/EasyCaching.InMemory/DefaultInMemoryCachingProvider.cs
+++ b/src/EasyCaching.InMemory/DefaultInMemoryCachingProvider.cs
@@ -4,6 +4,7 @@
     using EasyCaching.Core.Internal;
     using Microsoft.Extensions.Caching.Memory;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -69,11 +70,11 @@
         /// <param name="cache">Microsoft MemoryCache.</param>
         public DefaultInMemoryCachingProvider(
             IMemoryCache cache,
-            InMemoryOptions options,
+            IOptions<InMemoryOptions> options,
             ILoggerFactory loggerFactory = null)
         {
             this._cache = cache;
-            this._options = options;
+            this._options = options.Value;
             this._logger = loggerFactory?.CreateLogger<DefaultInMemoryCachingProvider>();
             this._cacheKeys = new ConcurrentCollections.ConcurrentHashSet<string>();
 

--- a/src/EasyCaching.InMemory/DefaultInMemoryCachingProvider.cs
+++ b/src/EasyCaching.InMemory/DefaultInMemoryCachingProvider.cs
@@ -59,6 +59,10 @@
         /// <value>The type of the caching provider.</value>
         public CachingProviderType CachingProviderType => _options.CachingProviderType;
 
+        private readonly CacheStats _cacheStats;
+
+        public CacheStats CacheStats => _cacheStats;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="T:EasyCaching.Memory.MemoryCachingProvider"/> class.
         /// </summary>
@@ -72,6 +76,8 @@
             this._options = options;
             this._logger = loggerFactory?.CreateLogger<DefaultInMemoryCachingProvider>();
             this._cacheKeys = new ConcurrentCollections.ConcurrentHashSet<string>();
+
+            this._cacheStats = new CacheStats();
         }
 
         /// <summary>
@@ -92,8 +98,15 @@
                 if (_options.EnableLogging)
                     _logger?.LogInformation($"Cache Hit : cachekey = {cacheKey}");
 
+                CacheStats.OnHit();
+
                 return new CacheValue<T>(result, true);
             }
+
+            CacheStats.OnMiss();
+
+            if (_options.EnableLogging)
+                _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
 
             result = dataRetriever?.Invoke();
 
@@ -103,10 +116,7 @@
                 return new CacheValue<T>(result, true);
             }
             else
-            {
-                if (_options.EnableLogging)
-                    _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
-
+            {                
                 return CacheValue<T>.NoValue;
             }
         }
@@ -129,8 +139,15 @@
                 if (_options.EnableLogging)
                     _logger?.LogInformation($"Cache Hit : cachekey = {cacheKey}");
 
+                CacheStats.OnHit();
+
                 return new CacheValue<T>(result, true);
             }
+
+            CacheStats.OnMiss();
+
+            if (_options.EnableLogging)
+                _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
 
             result = await dataRetriever?.Invoke();
 
@@ -140,10 +157,7 @@
                 return new CacheValue<T>(result, true);
             }
             else
-            {
-                if (_options.EnableLogging)
-                    _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
-
+            {                
                 return CacheValue<T>.NoValue;
             }
         }
@@ -163,12 +177,16 @@
                 if (_options.EnableLogging)
                     _logger?.LogInformation($"Cache Hit : cachekey = {cacheKey}");
 
+                CacheStats.OnHit();
+
                 return new CacheValue<T>(result, true);
             }
             else
             {
                 if (_options.EnableLogging)
                     _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
+
+                CacheStats.OnMiss();
 
                 return CacheValue<T>.NoValue;
             }
@@ -191,12 +209,16 @@
                 if (_options.EnableLogging)
                     _logger?.LogInformation($"Cache Hit : cachekey = {cacheKey}");
 
+                CacheStats.OnHit();
+
                 return new CacheValue<T>(result, true);
             }
             else
             {
                 if (_options.EnableLogging)
                     _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
+
+                CacheStats.OnMiss();
 
                 return CacheValue<T>.NoValue;
             }

--- a/src/EasyCaching.InMemory/EasyCaching.InMemory.csproj
+++ b/src/EasyCaching.InMemory/EasyCaching.InMemory.csproj
@@ -27,5 +27,6 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0" />
     <PackageReference Include="ConcurrentHashSet" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.1" />
   </ItemGroup>
 </Project>

--- a/src/EasyCaching.InMemory/InMemoryCacheServiceCollectionExtensions.cs
+++ b/src/EasyCaching.InMemory/InMemoryCacheServiceCollectionExtensions.cs
@@ -2,8 +2,10 @@
 {    
     using EasyCaching.Core;
     using EasyCaching.Core.Internal;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Extensions.Options;
     using System;
 
     /// <summary>
@@ -43,7 +45,29 @@
 
             var option = new InMemoryOptions();
             optionSetup(option);
-            services.AddSingleton(option);
+            //services.AddSingleton(option);
+
+            services.AddSingleton<IOptions<InMemoryOptions>>(new OptionsWrapper<InMemoryOptions>(option));
+
+
+            services.AddMemoryCache();
+            services.TryAddSingleton<IEasyCachingProvider, DefaultInMemoryCachingProvider>();
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds the default in-memory cache.
+        /// </summary>
+        /// <returns>The default in memory cache.</returns>
+        /// <param name="services">Services.</param>
+        /// <param name="configuration">Configuration.</param>
+        public static IServiceCollection AddDefaultInMemoryCache(
+           this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            var dbConfig = configuration.GetSection("easycaching");
+            services.Configure<InMemoryOptions>(dbConfig);
 
             services.AddMemoryCache();
             services.TryAddSingleton<IEasyCachingProvider, DefaultInMemoryCachingProvider>();

--- a/src/EasyCaching.InMemory/InMemoryCacheServiceCollectionExtensions.cs
+++ b/src/EasyCaching.InMemory/InMemoryCacheServiceCollectionExtensions.cs
@@ -66,7 +66,7 @@
            this IServiceCollection services,
             IConfiguration configuration)
         {
-            var dbConfig = configuration.GetSection("easycaching");
+            var dbConfig = configuration.GetSection(EasyCachingConstValue.ConfigSection);
             services.Configure<InMemoryOptions>(dbConfig);
 
             services.AddMemoryCache();

--- a/src/EasyCaching.Memcached/DefaultMemcachedCachingProvider.cs
+++ b/src/EasyCaching.Memcached/DefaultMemcachedCachingProvider.cs
@@ -55,7 +55,9 @@
         /// <value>The type of the caching provider.</value>
         public CachingProviderType CachingProviderType => _options.CachingProviderType;
 
-        public CacheStats CacheStats => throw new NotImplementedException();
+        private readonly CacheStats _cacheStats;
+
+        public CacheStats CacheStats => _cacheStats;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:EasyCaching.Memcached.DefaultMemcachedCachingProvider"/> class.
@@ -69,6 +71,8 @@
             this._memcachedClient = memcachedClient;
             this._options = options;
             this._logger = loggerFactory?.CreateLogger<DefaultMemcachedCachingProvider>();
+
+            this._cacheStats = new CacheStats();
         }
 
         /// <summary>
@@ -86,11 +90,18 @@
 
             if (_memcachedClient.Get(this.HandleCacheKey(cacheKey)) is T result)
             {
+                CacheStats.OnHit();
+
                 if (_options.EnableLogging)
                     _logger?.LogInformation($"Cache Hit : cachekey = {cacheKey}");
 
                 return new CacheValue<T>(result, true);
             }
+
+            CacheStats.OnMiss();
+
+            if (_options.EnableLogging)
+                _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
 
             var item = dataRetriever?.Invoke();
             if (item != null)
@@ -100,9 +111,6 @@
             }
             else
             {
-                if (_options.EnableLogging)
-                    _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
-
                 return CacheValue<T>.NoValue;
             }
         }
@@ -123,11 +131,18 @@
             var result = await _memcachedClient.GetValueAsync<T>(this.HandleCacheKey(cacheKey));
             if (result != null)
             {
+                CacheStats.OnHit();
+
                 if (_options.EnableLogging)
                     _logger?.LogInformation($"Cache Hit : cachekey = {cacheKey}");
 
                 return new CacheValue<T>(result, true);
             }
+
+            CacheStats.OnMiss();
+
+            if (_options.EnableLogging)
+                _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
 
             var item = await dataRetriever?.Invoke();
             if (item != null)
@@ -136,10 +151,7 @@
                 return new CacheValue<T>(item, true);
             }
             else
-            {
-                if (_options.EnableLogging)
-                    _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
-
+            {              
                 return CacheValue<T>.NoValue;
             }
         }
@@ -156,6 +168,8 @@
 
             if (_memcachedClient.Get(this.HandleCacheKey(cacheKey)) is T result)
             {
+                CacheStats.OnHit();
+                
                 if (_options.EnableLogging)
                     _logger?.LogInformation($"Cache Hit : cachekey = {cacheKey}");
 
@@ -163,6 +177,8 @@
             }
             else
             {
+                CacheStats.OnMiss();
+
                 if (_options.EnableLogging)
                     _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
 
@@ -183,6 +199,8 @@
             var result = await _memcachedClient.GetValueAsync<T>(this.HandleCacheKey(cacheKey));
             if (result != null)
             {
+                CacheStats.OnHit();
+
                 if (_options.EnableLogging)
                     _logger?.LogInformation($"Cache Hit : cachekey = {cacheKey}");
 
@@ -190,6 +208,8 @@
             }
             else
             {
+                CacheStats.OnMiss();
+
                 if (_options.EnableLogging)
                     _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
 

--- a/src/EasyCaching.Memcached/DefaultMemcachedCachingProvider.cs
+++ b/src/EasyCaching.Memcached/DefaultMemcachedCachingProvider.cs
@@ -55,6 +55,8 @@
         /// <value>The type of the caching provider.</value>
         public CachingProviderType CachingProviderType => _options.CachingProviderType;
 
+        public CacheStats CacheStats => throw new NotImplementedException();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="T:EasyCaching.Memcached.DefaultMemcachedCachingProvider"/> class.
         /// </summary>

--- a/src/EasyCaching.Redis/DefaultRedisCachingProvider.cs
+++ b/src/EasyCaching.Redis/DefaultRedisCachingProvider.cs
@@ -3,6 +3,7 @@
     using EasyCaching.Core;
     using EasyCaching.Core.Internal;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
     using StackExchange.Redis;
     using System;
     using System.Collections.Generic;
@@ -80,7 +81,7 @@
         public DefaultRedisCachingProvider(
             IRedisDatabaseProvider dbProvider,
             IEasyCachingSerializer serializer,
-            RedisOptions options,
+            IOptions<RedisOptions> options,
             ILoggerFactory loggerFactory = null)
         {
             ArgumentCheck.NotNull(dbProvider, nameof(dbProvider));
@@ -88,7 +89,7 @@
 
             this._dbProvider = dbProvider;
             this._serializer = serializer;
-            this._options = options;
+            this._options = options.Value;
             this._logger = loggerFactory?.CreateLogger<DefaultRedisCachingProvider>();
             this._cache = _dbProvider.GetDatabase();
             this._servers = _dbProvider.GetServerList();

--- a/src/EasyCaching.Redis/DefaultRedisCachingProvider.cs
+++ b/src/EasyCaching.Redis/DefaultRedisCachingProvider.cs
@@ -68,6 +68,8 @@
         /// <value>The type of the caching provider.</value>
         public CachingProviderType CachingProviderType => _options.CachingProviderType;
 
+        public CacheStats CacheStats => throw new NotImplementedException();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="T:EasyCaching.Redis.DefaultRedisCachingProvider"/> class.
         /// </summary>

--- a/src/EasyCaching.Redis/EasyCaching.Redis.csproj
+++ b/src/EasyCaching.Redis/EasyCaching.Redis.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyCaching.Core\EasyCaching.Core.csproj" />

--- a/src/EasyCaching.Redis/RedisCacheServiceCollectionExtensions.cs
+++ b/src/EasyCaching.Redis/RedisCacheServiceCollectionExtensions.cs
@@ -2,8 +2,10 @@
 {
     using EasyCaching.Core;
     using EasyCaching.Core.Internal;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Extensions.Options;
     using System;
 
     /// <summary>
@@ -52,13 +54,61 @@
 
             var providerOption = new RedisOptions();
             providerAction(providerOption);
-            services.AddSingleton(providerOption);
+            //services.AddSingleton(providerOption);
+            services.AddSingleton<IOptions<RedisOptions>>(new OptionsWrapper<RedisOptions>(providerOption));
 
             services.TryAddSingleton<IEasyCachingSerializer, DefaultBinaryFormatterSerializer>();
             services.TryAddSingleton<IRedisDatabaseProvider, RedisDatabaseProvider>();
             services.TryAddSingleton<IEasyCachingProvider, DefaultRedisCachingProvider>();
 
             return services;
-        }               
+        }              
+
+        /// <summary>
+        /// Adds the default redis cache.
+        /// </summary>
+        /// <example>
+        /// <![CDATA[
+        /// "easycaching": {
+        ///     "CachingProviderType": 3,
+        ///     "MaxRdSecond": 120,
+        ///     "Order": 2,
+        ///     "dbconfig": {            
+        ///         "Password": null,
+        ///         "IsSsl": false,
+        ///         "SslHost": null,
+        ///         "ConnectionTimeout": 5000,
+        ///         "AllowAdmin": true,
+        ///         "Endpoints": [
+        ///             {
+        ///                 "Host": "localhost",
+        ///                 "Port": 6739
+        ///             }
+        ///         ],
+        ///         "Database": 0
+        ///     }
+        /// }      
+        /// ]]>
+        /// </example>
+        /// <returns>The default redis cache.</returns>
+        /// <param name="services">Services.</param>
+        /// <param name="configuration">Configuration.</param>
+        public static IServiceCollection AddDefaultRedisCache(
+           this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            var cacheConfig = configuration.GetSection(EasyCachingConstValue.ConfigSection);
+            services.Configure<RedisOptions>(cacheConfig);
+
+            var redisConfig = configuration.GetSection(EasyCachingConstValue.ConfigChildSection);
+            services.Configure<RedisDBOptions>(redisConfig);
+
+            services.TryAddSingleton<IEasyCachingSerializer, DefaultBinaryFormatterSerializer>();
+            services.TryAddSingleton<IRedisDatabaseProvider, RedisDatabaseProvider>();
+            services.TryAddSingleton<IEasyCachingProvider, DefaultRedisCachingProvider>();
+
+            return services;
+        }
+
     }
 }

--- a/src/EasyCaching.SQLite/DefaultSQLiteCachingProvider.cs
+++ b/src/EasyCaching.SQLite/DefaultSQLiteCachingProvider.cs
@@ -74,6 +74,8 @@
         /// <value>The type of the caching provider.</value>
         public CachingProviderType CachingProviderType => _options.CachingProviderType;
 
+        public CacheStats CacheStats => throw new NotImplementedException();
+
         /// <summary>
         /// Exists the specified cacheKey.
         /// </summary>

--- a/src/EasyCaching.SQLite/DefaultSQLiteCachingProvider.cs
+++ b/src/EasyCaching.SQLite/DefaultSQLiteCachingProvider.cs
@@ -5,6 +5,7 @@
     using EasyCaching.Core.Internal;
     using Microsoft.Data.Sqlite;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -41,11 +42,11 @@
         /// <param name="dbProvider">dbProvider.</param>
         public DefaultSQLiteCachingProvider(
             ISQLiteDatabaseProvider dbProvider,
-            SQLiteOptions options,
+            IOptions<SQLiteOptions> options,
             ILoggerFactory loggerFactory = null)
         {
             this._dbProvider = dbProvider;
-            this._options = options;
+            this._options = options.Value;
             this._logger = loggerFactory?.CreateLogger<DefaultSQLiteCachingProvider>();
             this._cache = _dbProvider.GetConnection();
             this._cacheStats = new CacheStats();

--- a/src/EasyCaching.SQLite/EasyCaching.SQLite.csproj
+++ b/src/EasyCaching.SQLite/EasyCaching.SQLite.csproj
@@ -30,5 +30,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.1" />
   </ItemGroup>
 </Project>

--- a/src/EasyCaching.SQLite/SQLiteCacheServiceCollectionExtensions.cs
+++ b/src/EasyCaching.SQLite/SQLiteCacheServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
     using System;
     using EasyCaching.Core;
     using EasyCaching.Core.Internal;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -57,6 +58,29 @@
             services.TryAddSingleton<IEasyCachingProvider, DefaultSQLiteCachingProvider>();
 
             return services;
-        }              
+        }             
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="services">Services.</param>
+        /// <param name="configuration">Configuration.</param>
+        public static IServiceCollection AddSQLiteCache(
+           this IServiceCollection services,
+            IConfiguration configuration,
+            Action<SQLiteDBOption> optionsAction)
+        {
+            var config = configuration.GetSection("easycaching");
+            services.Configure<SQLiteDBOption>(config);
+
+            var providerOptions = new SQLiteOptions();
+
+            return services.AddSQLiteCache(optionsAction, x =>
+            {
+                x.CachingProviderType = providerOptions.CachingProviderType;
+                x.MaxRdSecond = providerOptions.MaxRdSecond;
+                x.Order = providerOptions.Order;
+            });                      
+        }
     }
 }

--- a/src/EasyCaching.SQLite/SQLiteCacheServiceCollectionExtensions.cs
+++ b/src/EasyCaching.SQLite/SQLiteCacheServiceCollectionExtensions.cs
@@ -64,6 +64,7 @@
         /// Adds the SQLite cache.
         /// </summary>
         /// <returns>The SQL ite cache.</returns>
+        /// <example>
         /// <![CDATA[
         /// "easycaching": {
         ///     "CachingProviderType": 3,
@@ -74,16 +75,17 @@
         ///     }
         /// }
         /// ]]>
+        /// </example>
         /// <param name="services">Services.</param>
         /// <param name="configuration">Configuration.</param>
         public static IServiceCollection AddSQLiteCache(
            this IServiceCollection services,
             IConfiguration configuration)
         {
-            var dbConfig = configuration.GetSection("easycaching");
+            var dbConfig = configuration.GetSection(EasyCachingConstValue.ConfigSection);
             services.Configure<SQLiteOptions>(dbConfig);
 
-            var sqliteConfig = configuration.GetSection("easycaching:dbconfig");
+            var sqliteConfig = configuration.GetSection(EasyCachingConstValue.ConfigChildSection);
             services.Configure<SQLiteDBOption>(sqliteConfig);
 
             services.TryAddSingleton<ISQLiteDatabaseProvider, SQLiteDatabaseProvider>();

--- a/src/EasyCaching.SQLite/SQLiteCacheServiceCollectionExtensions.cs
+++ b/src/EasyCaching.SQLite/SQLiteCacheServiceCollectionExtensions.cs
@@ -61,26 +61,35 @@
         }             
 
         /// <summary>
-        /// 
+        /// Adds the SQLite cache.
         /// </summary>
+        /// <returns>The SQL ite cache.</returns>
+        /// <![CDATA[
+        /// "easycaching": {
+        ///     "CachingProviderType": 3,
+        ///     "MaxRdSecond": 120,
+        ///     "Order": 2,
+        ///     "dbconfig": {            
+        ///         "FileName": "my.db"
+        ///     }
+        /// }
+        /// ]]>
         /// <param name="services">Services.</param>
         /// <param name="configuration">Configuration.</param>
         public static IServiceCollection AddSQLiteCache(
            this IServiceCollection services,
-            IConfiguration configuration,
-            Action<SQLiteDBOption> optionsAction)
+            IConfiguration configuration)
         {
-            var config = configuration.GetSection("easycaching");
-            services.Configure<SQLiteDBOption>(config);
+            var dbConfig = configuration.GetSection("easycaching");
+            services.Configure<SQLiteOptions>(dbConfig);
 
-            var providerOptions = new SQLiteOptions();
+            var sqliteConfig = configuration.GetSection("easycaching:dbconfig");
+            services.Configure<SQLiteDBOption>(sqliteConfig);
 
-            return services.AddSQLiteCache(optionsAction, x =>
-            {
-                x.CachingProviderType = providerOptions.CachingProviderType;
-                x.MaxRdSecond = providerOptions.MaxRdSecond;
-                x.Order = providerOptions.Order;
-            });                      
+            services.TryAddSingleton<ISQLiteDatabaseProvider, SQLiteDatabaseProvider>();
+            services.TryAddSingleton<IEasyCachingProvider, DefaultSQLiteCachingProvider>();
+
+            return services;
         }
     }
 }

--- a/test/EasyCaching.UnitTests/CachingTests/BaseCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/BaseCachingProviderTest.cs
@@ -991,5 +991,32 @@
             return func;
         }
         #endregion
+
+        [Fact]
+        protected virtual void OnHit_Should_Return_One_And_OnMiss_Should_Return_Zero()
+        {
+            var cacheKey = Guid.NewGuid().ToString();
+            _provider.Set(cacheKey, "onhit", _defaultTs);
+            _provider.Get<string>(cacheKey);
+
+            var hitRes = _provider.CacheStats.GetStatistic(StatsType.Hit);
+            var missedRes = _provider.CacheStats.GetStatistic(StatsType.Missed);
+
+            Assert.Equal(1, hitRes);
+            Assert.Equal(0, missedRes);
+        }
+
+        [Fact]
+        protected virtual void OnHit_Should_Return_Zero_And_OnMiss_Should_Return_One()
+        {
+            var cacheKey = Guid.NewGuid().ToString();
+            _provider.Get<string>(cacheKey);
+
+            var hitRes = _provider.CacheStats.GetStatistic(StatsType.Hit);
+            var missedRes = _provider.CacheStats.GetStatistic(StatsType.Missed);
+
+            Assert.Equal(0, hitRes);
+            Assert.Equal(1, missedRes);
+        }
     }
 }

--- a/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
@@ -59,6 +59,16 @@
 
         }
 
+        [Fact]
+        protected override void OnHit_Should_Return_One_And_OnMiss_Should_Return_Zero()
+        {
+            
+        }
 
+        [Fact]
+        protected override void OnHit_Should_Return_Zero_And_OnMiss_Should_Return_One()
+        {
+
+        }
     }
 }

--- a/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
@@ -40,7 +40,7 @@
             var providers = new List<IEasyCachingProvider>
             {
                 new DefaultInMemoryCachingProvider(new MemoryCache(new MemoryCacheOptions()), new OptionsWrapper<InMemoryOptions>(new InMemoryOptions())),
-                new DefaultRedisCachingProvider(fakeDbProvider, serializer, new RedisOptions())
+                new DefaultRedisCachingProvider(fakeDbProvider, serializer, new OptionsWrapper<RedisOptions>(new RedisOptions()))
             };
 
             _provider = new HybridCachingProvider(providers);

--- a/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
@@ -39,7 +39,7 @@
 
             var providers = new List<IEasyCachingProvider>
             {
-                new DefaultInMemoryCachingProvider(new MemoryCache(new MemoryCacheOptions()), new InMemoryOptions()),
+                new DefaultInMemoryCachingProvider(new MemoryCache(new MemoryCacheOptions()), new OptionsWrapper<InMemoryOptions>(new InMemoryOptions())),
                 new DefaultRedisCachingProvider(fakeDbProvider, serializer, new RedisOptions())
             };
 

--- a/test/EasyCaching.UnitTests/CachingTests/SQLiteCachingTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/SQLiteCachingTest.cs
@@ -3,6 +3,7 @@
     using Dapper;
     using EasyCaching.SQLite;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Options;
     using System;
 
     public class SQLiteCachingTest : BaseCachingProviderTest
@@ -30,7 +31,7 @@
             }
             conn.Execute(ConstSQL.CREATESQL);
 
-            _provider = new DefaultSQLiteCachingProvider(_dbProvider, new SQLiteOptions());
+            _provider = new DefaultSQLiteCachingProvider(_dbProvider, new OptionsWrapper<SQLiteOptions>(new SQLiteOptions()));
             _defaultTs = TimeSpan.FromSeconds(30);
         }
     }


### PR DESCRIPTION
1. Add cache stats to enable count hit and missed cache items.
2. Add ServiceCollectionExtensions so that we can read from configuration files, such as `appsettings.json`.(#41 )
