### PR TITLE
Redesign InMemory And Add Mutex Key

### DIFF
--- a/build/releasenotes.props
+++ b/build/releasenotes.props
@@ -1,19 +1,21 @@
 <Project>
 	<PropertyGroup>
 		<EasyCachingCorePackageNotes>
-        1. Improve Configuration.
+        1. Update BaseRedisOptions.
         </EasyCachingCorePackageNotes>
 		<EasyCachingMemcachedPackageNotes>
-        1. Improve Configuration.
+        1. Improve Get cached value.
         </EasyCachingMemcachedPackageNotes>
 		<EasyCachingRedisPackageNotes>
-        1. Improve Configuration.
+        1. Update Options.
+        2. Improve Get cached value.
         </EasyCachingRedisPackageNotes>
 		<EasyCachingSQLitePackageNotes>
         1. Improve Configuration.
         </EasyCachingSQLitePackageNotes>
 		<EasyCachingInMemoryPackageNotes>
-        1. Redesign.
+        1. Update Options.
+        2. Improve Get cached value.
         </EasyCachingInMemoryPackageNotes>
 		<EasyCachingHybridPackageNotes>
         1. Improve Configuration.

--- a/build/releasenotes.props
+++ b/build/releasenotes.props
@@ -13,7 +13,7 @@
         1. Improve Configuration.
         </EasyCachingSQLitePackageNotes>
 		<EasyCachingInMemoryPackageNotes>
-        1. Improve Configuration.
+        1. Redesign.
         </EasyCachingInMemoryPackageNotes>
 		<EasyCachingHybridPackageNotes>
         1. Improve Configuration.

--- a/build/version.props
+++ b/build/version.props
@@ -1,10 +1,10 @@
 <Project>
 	<PropertyGroup>
-		<EasyCachingCorePackageVersion>0.4.5</EasyCachingCorePackageVersion>
-		<EasyCachingMemcachedPackageVersion>0.4.5</EasyCachingMemcachedPackageVersion>
-		<EasyCachingRedisPackageVersion>0.4.5</EasyCachingRedisPackageVersion>
+		<EasyCachingCorePackageVersion>0.4.5.1</EasyCachingCorePackageVersion>
+		<EasyCachingMemcachedPackageVersion>0.4.5.1</EasyCachingMemcachedPackageVersion>
+		<EasyCachingRedisPackageVersion>0.4.5.1</EasyCachingRedisPackageVersion>
 		<EasyCachingSQLitePackageVersion>0.4.5</EasyCachingSQLitePackageVersion>
-		<EasyCachingInMemoryPackageVersion>0.4.5.2</EasyCachingInMemoryPackageVersion>
+		<EasyCachingInMemoryPackageVersion>0.4.5.3</EasyCachingInMemoryPackageVersion>
 		<EasyCachingHybridPackageVersion>0.4.5</EasyCachingHybridPackageVersion>
 		<EasyCachingAspectCorePackageVersion>0.3.2</EasyCachingAspectCorePackageVersion>
 		<EasyCachingCastlePackageVersion>0.3.2</EasyCachingCastlePackageVersion>

--- a/build/version.props
+++ b/build/version.props
@@ -4,7 +4,7 @@
 		<EasyCachingMemcachedPackageVersion>0.4.5</EasyCachingMemcachedPackageVersion>
 		<EasyCachingRedisPackageVersion>0.4.5</EasyCachingRedisPackageVersion>
 		<EasyCachingSQLitePackageVersion>0.4.5</EasyCachingSQLitePackageVersion>
-		<EasyCachingInMemoryPackageVersion>0.4.5</EasyCachingInMemoryPackageVersion>
+		<EasyCachingInMemoryPackageVersion>0.4.5.1-alpha</EasyCachingInMemoryPackageVersion>
 		<EasyCachingHybridPackageVersion>0.4.5</EasyCachingHybridPackageVersion>
 		<EasyCachingAspectCorePackageVersion>0.3.2</EasyCachingAspectCorePackageVersion>
 		<EasyCachingCastlePackageVersion>0.3.2</EasyCachingCastlePackageVersion>

--- a/build/version.props
+++ b/build/version.props
@@ -4,7 +4,7 @@
 		<EasyCachingMemcachedPackageVersion>0.4.5</EasyCachingMemcachedPackageVersion>
 		<EasyCachingRedisPackageVersion>0.4.5</EasyCachingRedisPackageVersion>
 		<EasyCachingSQLitePackageVersion>0.4.5</EasyCachingSQLitePackageVersion>
-		<EasyCachingInMemoryPackageVersion>0.4.5.1-alpha</EasyCachingInMemoryPackageVersion>
+		<EasyCachingInMemoryPackageVersion>0.4.5.2</EasyCachingInMemoryPackageVersion>
 		<EasyCachingHybridPackageVersion>0.4.5</EasyCachingHybridPackageVersion>
 		<EasyCachingAspectCorePackageVersion>0.3.2</EasyCachingAspectCorePackageVersion>
 		<EasyCachingCastlePackageVersion>0.3.2</EasyCachingCastlePackageVersion>

--- a/src/EasyCaching.Core/CacheValue.cs
+++ b/src/EasyCaching.Core/CacheValue.cs
@@ -1,5 +1,7 @@
 ﻿namespace EasyCaching.Core
 {
+    using System;
+
     /// <summary>
     /// Cache value.
     /// </summary>
@@ -10,10 +12,16 @@
         /// </summary>
         /// <param name="value">Value.</param>
         /// <param name="hasValue">If set to <c>true</c> has value.</param>
-        public CacheValue(T value, bool hasValue)
+        public CacheValue(T value, bool hasValue, TimeSpan? ts = null)
         {
             Value = value;
             HasValue = hasValue;
+
+            if(ts.HasValue)
+            {
+                ExpiresAt = DateTimeOffset.UtcNow.Add(ts.Value);
+            }
+
         }
 
         /// <summary>
@@ -33,6 +41,12 @@
         /// </summary>
         /// <value>The value.</value>
         public T Value { get; }
+
+        /// <summary>
+        /// Gets or sets the expires at.
+        /// </summary>
+        /// <value>The expires at.</value>
+        public DateTimeOffset ExpiresAt { get; set; }
 
         /// <summary>
         /// Gets the null.

--- a/src/EasyCaching.Core/Internal/BaseProviderOptions.cs
+++ b/src/EasyCaching.Core/Internal/BaseProviderOptions.cs
@@ -37,5 +37,17 @@
         /// </summary>
         /// <value><c>true</c> if enable logging; otherwise, <c>false</c>.</value>
         public bool EnableLogging { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sleep ms.
+        /// </summary>
+        /// <value>The sleep ms.</value>
+        public int SleepMs { get; set; } = 300;
+
+        /// <summary>
+        /// Gets or sets the lock ms.
+        /// </summary>
+        /// <value>The lock ms.</value>
+        public int LockMs { get; set; } = 5000;
     }
 }

--- a/src/EasyCaching.Core/Internal/BaseRedisOptions.cs
+++ b/src/EasyCaching.Core/Internal/BaseRedisOptions.cs
@@ -61,5 +61,11 @@
         /// <value>The configuration.</value>
         public string Configuration { get; set; } = "";
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="T:EasyCaching.Core.Internal.BaseRedisOptions"/>
+        /// abort on connect fail.
+        /// </summary>
+        /// <value><c>true</c> if abort on connect fail; otherwise, <c>false</c>.</value>
+        public bool AbortOnConnectFail { get; set; } = false;
     }
 }

--- a/src/EasyCaching.InMemory/Configurations/EasyCachingOptionsExtensions.cs
+++ b/src/EasyCaching.InMemory/Configurations/EasyCachingOptionsExtensions.cs
@@ -59,9 +59,9 @@
         /// <param name="options">Options.</param>
         /// <param name="configuration">Configuration.</param>
         /// <param name="name">Name.</param>
-        public static EasyCachingOptions UseInMemory(this EasyCachingOptions options, IConfiguration configuration, string name = "")
+        public static EasyCachingOptions UseInMemory(this EasyCachingOptions options, IConfiguration configuration, string name = "", string sectionName = EasyCachingConstValue.InMemorySection)
         {
-            var dbConfig = configuration.GetSection(EasyCachingConstValue.InMemorySection);
+            var dbConfig = configuration.GetSection(sectionName);
             var memoryOptions = new InMemoryOptions();
             dbConfig.Bind(memoryOptions);
 

--- a/src/EasyCaching.InMemory/Configurations/EasyCachingOptionsExtensions.cs
+++ b/src/EasyCaching.InMemory/Configurations/EasyCachingOptionsExtensions.cs
@@ -25,6 +25,7 @@
                 x.EnableLogging = option.EnableLogging;
                 x.MaxRdSecond = option.MaxRdSecond;
                 x.Order = option.Order;
+                x.DBConfig = option.DBConfig;
             }
 
             options.RegisterExtension(new InMemoryOptionsExtension(name, configure));
@@ -70,6 +71,7 @@
                 x.EnableLogging = memoryOptions.EnableLogging;
                 x.MaxRdSecond = memoryOptions.MaxRdSecond;
                 x.Order = memoryOptions.Order;
+                x.DBConfig = memoryOptions.DBConfig;
             }
 
             options.RegisterExtension(new InMemoryOptionsExtension(name, configure));

--- a/src/EasyCaching.InMemory/Configurations/InMemoryOptions.cs
+++ b/src/EasyCaching.InMemory/Configurations/InMemoryOptions.cs
@@ -9,5 +9,7 @@
         {
             this.CachingProviderType = CachingProviderType.InMemory;
         }
+
+        public InMemoryCachingOptions DBConfig { get; set; } = new InMemoryCachingOptions();
     }
 }

--- a/src/EasyCaching.InMemory/Configurations/InMemoryOptionsExtension.cs
+++ b/src/EasyCaching.InMemory/Configurations/InMemoryOptionsExtension.cs
@@ -38,7 +38,7 @@
         {
             services.AddOptions();
             services.Configure(configure);
-            services.AddMemoryCache();
+            services.AddSingleton<IInMemoryCaching, InMemoryCaching>();
 
             if (string.IsNullOrWhiteSpace(_name))
             {
@@ -49,7 +49,7 @@
                 services.AddSingleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>();
                 services.AddSingleton<IEasyCachingProvider, DefaultInMemoryCachingProvider>(x =>
                 {
-                    var mCache = x.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>();
+                    var mCache = x.GetRequiredService<IInMemoryCaching>();
                     var options = x.GetRequiredService<Microsoft.Extensions.Options.IOptionsMonitor<InMemoryOptions>>();
                     //ILoggerFactory can be null
                     var factory = x.GetService<Microsoft.Extensions.Logging.ILoggerFactory>();

--- a/src/EasyCaching.InMemory/EasyCaching.InMemory.csproj
+++ b/src/EasyCaching.InMemory/EasyCaching.InMemory.csproj
@@ -24,11 +24,10 @@
     <ProjectReference Include="..\EasyCaching.Core\EasyCaching.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
-    <PackageReference Include="ConcurrentHashSet" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Configurations\" />
+    <Folder Include="Internal\" />
   </ItemGroup>
 </Project>

--- a/src/EasyCaching.InMemory/InMemoryCacheServiceCollectionExtensions.cs
+++ b/src/EasyCaching.InMemory/InMemoryCacheServiceCollectionExtensions.cs
@@ -1,5 +1,5 @@
 ﻿namespace EasyCaching.InMemory
-{    
+{
     using EasyCaching.Core;
     using EasyCaching.Core.Internal;
     using Microsoft.Extensions.Configuration;
@@ -17,10 +17,10 @@
         /// <returns>The default in-memory cache.</returns>
         /// <param name="services">Services.</param>
         public static IServiceCollection AddDefaultInMemoryCache(this IServiceCollection services)
-        {            
+        {
             var option = new InMemoryOptions();
 
-            return services.AddDefaultInMemoryCache(x=>
+            return services.AddDefaultInMemoryCache(x =>
             {
                 x.CachingProviderType = option.CachingProviderType;
                 x.MaxRdSecond = option.MaxRdSecond;
@@ -35,7 +35,7 @@
         /// <param name="services">Services.</param>
         /// <param name="providerAction">Option.</param>
         public static IServiceCollection AddDefaultInMemoryCache(
-            this IServiceCollection services, 
+            this IServiceCollection services,
             Action<InMemoryOptions> providerAction)
         {
             ArgumentCheck.NotNull(services, nameof(services));
@@ -43,8 +43,9 @@
 
             services.AddOptions();
             services.Configure(providerAction);
-                       
-            services.AddMemoryCache();
+
+            //services.AddMemoryCache();
+            services.AddSingleton<IInMemoryCaching, InMemoryCaching>();
             services.AddSingleton<IEasyCachingProvider, DefaultInMemoryCachingProvider>();
 
             return services;
@@ -74,7 +75,7 @@
             var dbConfig = configuration.GetSection(EasyCachingConstValue.InMemorySection);
             services.Configure<InMemoryOptions>(dbConfig);
 
-            services.AddMemoryCache();
+            services.AddSingleton<IInMemoryCaching, InMemoryCaching>();
             services.AddSingleton<IEasyCachingProvider, DefaultInMemoryCachingProvider>();
 
             return services;
@@ -119,16 +120,16 @@
             services.AddOptions();
             services.Configure(providerAction);
 
-            services.AddMemoryCache();
+            services.AddSingleton<IInMemoryCaching, InMemoryCaching>();
 
             services.AddSingleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>();
-            services.AddSingleton<IEasyCachingProvider, DefaultInMemoryCachingProvider>(x=>
+            services.AddSingleton<IEasyCachingProvider, DefaultInMemoryCachingProvider>(x =>
             {
-                var mCache = x.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>();
+                var mCache = x.GetRequiredService<IInMemoryCaching>();
                 var options = x.GetRequiredService<Microsoft.Extensions.Options.IOptionsMonitor<InMemoryOptions>>();
                 //ILoggerFactory can be null
                 var factory = x.GetService<Microsoft.Extensions.Logging.ILoggerFactory>();
-                return new DefaultInMemoryCachingProvider(providerName, mCache, options,factory);                           
+                return new DefaultInMemoryCachingProvider(providerName, mCache, options, factory);
             });
 
             return services;

--- a/src/EasyCaching.InMemory/Internal/IInMemoryCaching.cs
+++ b/src/EasyCaching.InMemory/Internal/IInMemoryCaching.cs
@@ -1,0 +1,23 @@
+﻿namespace EasyCaching.InMemory
+{
+    using EasyCaching.Core;
+    using System;
+    using System.Collections.Generic;
+
+    public interface IInMemoryCaching
+    {
+        int GetCount(string prefix = "");
+        CacheValue<T> Get<T>(string key);
+        IDictionary<string, CacheValue<T>> GetByPrefix<T>(string key);
+        bool Add<T>(string key, T value, TimeSpan? expiresIn = null);
+        bool Set<T>(string key, T value, TimeSpan? expiresIn = null);
+        bool Exists(string key);
+        int RemoveAll(IEnumerable<string> keys = null);
+        bool Remove(string key);
+        int RemoveByPrefix(string prefix);
+        IDictionary<string, CacheValue<T>> GetAll<T>(IEnumerable<string> keys);
+        int SetAll<T>(IDictionary<string, T> values, TimeSpan? expiresIn = null);
+        bool Replace<T>(string key, T value, TimeSpan? expiresIn = null);
+        void Clear(string prefix = "");
+    }
+}

--- a/src/EasyCaching.InMemory/Internal/InMemoryCaching.cs
+++ b/src/EasyCaching.InMemory/Internal/InMemoryCaching.cs
@@ -187,7 +187,7 @@
 
             var list = new List<bool>();
 
-            foreach (var entry in values) list.Add(Set(entry.Key, entry.Value));
+            foreach (var entry in values) list.Add(Set(entry.Key, entry.Value, expiresIn));
 
             return list.Count(r => r);
         }

--- a/src/EasyCaching.InMemory/Internal/InMemoryCaching.cs
+++ b/src/EasyCaching.InMemory/Internal/InMemoryCaching.cs
@@ -1,0 +1,288 @@
+﻿namespace EasyCaching.InMemory
+{
+    using EasyCaching.Core.Internal;
+    using EasyCaching.Core;
+    using Microsoft.Extensions.Options;
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class InMemoryCaching : IInMemoryCaching
+    {
+        private readonly ConcurrentDictionary<string, CacheEntry> _memory;
+        private DateTimeOffset _lastExpirationScan;
+        private readonly InMemoryCachingOptions _options;
+
+        public InMemoryCaching(IOptions<InMemoryCachingOptions> optionsAccessor)
+        {
+            ArgumentCheck.NotNull(optionsAccessor, nameof(optionsAccessor));
+
+            _options = optionsAccessor.Value;
+            _memory = new ConcurrentDictionary<string, CacheEntry>();
+            _lastExpirationScan = SystemClock.UtcNow;
+        }
+
+        public void Clear(string prefix = "")
+        {
+            if (string.IsNullOrWhiteSpace(prefix))
+            {
+                _memory.Clear();
+            }
+            else
+            {
+                RemoveByPrefix(prefix);
+            }
+        }
+
+        public int GetCount(string prefix = "")
+        {
+            return string.IsNullOrWhiteSpace(prefix)
+                ? _memory.Count
+                : _memory.Count(x => x.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+        }
+
+        internal void RemoveExpiredKey(string key)
+        {
+            _memory.TryRemove(key, out _);
+        }
+
+        public CacheValue<T> Get<T>(string key)
+        {
+            ArgumentCheck.NotNullOrWhiteSpace(key, nameof(key));
+
+            if (!_memory.TryGetValue(key, out var cacheEntry))
+            {
+                return CacheValue<T>.NoValue;
+            }
+
+            if (cacheEntry.ExpiresAt < SystemClock.UtcNow)
+            {
+                _memory.TryRemove(key, out _);
+                return CacheValue<T>.NoValue;
+            }
+
+            try
+            {
+                var value = cacheEntry.GetValue<T>();
+                return new CacheValue<T>(value, true);
+            }
+            catch
+            {
+                return CacheValue<T>.NoValue;
+            }
+        }
+
+        public bool Add<T>(string key, T value, TimeSpan? expiresIn = null)
+        {
+            ArgumentCheck.NotNullOrWhiteSpace(key, nameof(key));
+
+            var expiresAt = expiresIn.HasValue ? SystemClock.UtcNow.SafeAdd(expiresIn.Value) : DateTime.MaxValue;
+            return SetInternal(new CacheEntry(key, value, expiresAt), true);
+        }
+
+        public bool Set<T>(string key, T value, TimeSpan? expiresIn = null)
+        {
+            ArgumentCheck.NotNullOrWhiteSpace(key, nameof(key));
+
+            var expiresAt = expiresIn.HasValue ? SystemClock.UtcNow.SafeAdd(expiresIn.Value) : DateTime.MaxValue;
+            return SetInternal(new CacheEntry(key, value, expiresAt));
+        }
+
+        private bool SetInternal(CacheEntry entry, bool addOnly = false)
+        {
+            if (entry.ExpiresAt < SystemClock.UtcNow)
+            {
+                RemoveExpiredKey(entry.Key);
+                return false;
+            }
+
+            if (_memory.Count >= _options.SizeLimit)
+            {
+                // order by last access ticks 
+                // up to size limit, should remove 
+                var oldestList = _memory.ToArray()
+                                   .OrderBy(kvp => kvp.Value.LastAccessTicks)
+                                   .ThenBy(kvp => kvp.Value.InstanceNumber)
+                                   .Take(5)
+                                   .Select(kvp => kvp.Key);
+
+                RemoveAll(oldestList);
+            }
+
+            if (addOnly)
+            {
+                if (!_memory.TryAdd(entry.Key, entry))
+                {
+                    if (!_memory.TryGetValue(entry.Key, out var existingEntry) || existingEntry.ExpiresAt >= SystemClock.UtcNow)
+                        return false;
+
+                    _memory.AddOrUpdate(entry.Key, entry, (k, cacheEntry) => entry);
+                }
+            }
+            else
+            {
+                _memory.AddOrUpdate(entry.Key, entry, (k, cacheEntry) => entry);
+            }
+
+            StartScanForExpiredItems();
+
+            return true;
+        }
+
+        public bool Exists(string key)
+        {
+            ArgumentCheck.NotNullOrWhiteSpace(key, nameof(key));
+
+            return _memory.ContainsKey(key);
+        }
+
+        public int RemoveAll(IEnumerable<string> keys = null)
+        {
+            if (keys == null)
+            {
+                int count = _memory.Count;
+                _memory.Clear();
+                return count;
+            }
+
+            int removed = 0;
+            foreach (string key in keys)
+            {
+                if (String.IsNullOrEmpty(key))
+                    continue;
+
+                if (_memory.TryRemove(key, out _))
+                    removed++;
+            }
+
+            return removed;
+        }
+
+        public bool Remove(string key)
+        {
+            return _memory.TryRemove(key, out _);
+        }
+
+        public int RemoveByPrefix(string prefix)
+        {
+            var keysToRemove = _memory.Keys.Where(x => x.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)).ToList();
+            return RemoveAll(keysToRemove);
+        }
+
+        public IDictionary<string, CacheValue<T>> GetAll<T>(IEnumerable<string> keys)
+        {
+            var map = new Dictionary<string, CacheValue<T>>();
+            foreach (string key in keys)
+                map[key] = Get<T>(key);
+
+            return map;
+        }
+
+        public int SetAll<T>(IDictionary<string, T> values, TimeSpan? expiresIn = null)
+        {
+            if (values == null || values.Count == 0) return 0;
+
+            var list = new List<bool>();
+
+            foreach (var entry in values) list.Add(Set(entry.Key, entry.Value));
+
+            return list.Count(r => r);
+        }
+
+        public bool Replace<T>(string key, T value, TimeSpan? expiresIn = null)
+        {
+            ArgumentCheck.NotNullOrWhiteSpace(key, nameof(key));
+
+            if (!_memory.ContainsKey(key)) return false;
+
+            return Set(key, value, expiresIn);
+        }
+
+        private void StartScanForExpiredItems()
+        {
+            var utcNow = SystemClock.UtcNow;
+            if (_options.ExpirationScanFrequency < utcNow - _lastExpirationScan)
+            {
+                _lastExpirationScan = utcNow;
+                Task.Factory.StartNew(state => ScanForExpiredItems((InMemoryCaching)state), this,
+                    CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            }
+        }
+
+        private void ScanForExpiredItems(InMemoryCaching cache)
+        {
+            var now = SystemClock.UtcNow;
+            foreach (var entry in cache._memory.Values.Where(x => x.ExpiresAt < now))
+            {
+                cache.Remove(entry.Key);
+            }
+        }
+
+        public IDictionary<string, CacheValue<T>> GetByPrefix<T>(string key)
+        {
+            var values = _memory.Values.Where(x => x.Key.StartsWith(key, StringComparison.OrdinalIgnoreCase) && x.ExpiresAt > SystemClock.UtcNow);
+            return values.ToDictionary(k => k.Key, v => new CacheValue<T>(v.GetValue<T>(), true));
+        }
+
+        private class CacheEntry
+        {
+            private object _cacheValue;
+            private static long _instanceCount;
+
+            public CacheEntry(string key, object value, DateTimeOffset expiresAt)
+            {
+                Key = key;
+                Value = value;
+                ExpiresAt = expiresAt;
+                LastModifiedTicks = SystemClock.UtcNow.Ticks;
+                InstanceNumber = Interlocked.Increment(ref _instanceCount);
+            }
+
+            internal string Key { get; private set; }
+            internal long InstanceNumber { get; private set; }
+            internal DateTimeOffset ExpiresAt { get; set; }
+            internal long LastAccessTicks { get; private set; }
+            internal long LastModifiedTicks { get; private set; }
+
+            /// <summary>
+            /// the cache value
+            /// </summary>
+            internal object Value
+            {
+                get
+                {
+                    LastAccessTicks = SystemClock.UtcNow.Ticks;
+                    return _cacheValue;
+                }
+                set
+                {
+                    _cacheValue = value;
+                    LastAccessTicks = SystemClock.UtcNow.Ticks;
+                    LastModifiedTicks = SystemClock.UtcNow.Ticks;
+                }
+            }
+
+            /// <summary>
+            /// conver to T
+            /// </summary>
+            /// <typeparam name="T"></typeparam>
+            /// <returns></returns>
+            public T GetValue<T>()
+            {
+                object val = Value;
+                var t = typeof(T);
+
+                if (t == TypeHelper.BoolType || t == TypeHelper.StringType || t == TypeHelper.CharType || t == TypeHelper.DateTimeType || t == TypeHelper.ObjectType || t.IsNumeric())
+                    return (T)Convert.ChangeType(val, t);
+
+                if (t == TypeHelper.NullableBoolType || t == TypeHelper.NullableCharType || t == TypeHelper.NullableDateTimeType || t.IsNullableNumeric())
+                    return val == null ? default(T) : (T)Convert.ChangeType(val, Nullable.GetUnderlyingType(t));
+
+                return (T)val;
+            }
+        }
+    }
+}

--- a/src/EasyCaching.InMemory/Internal/InMemoryCaching.cs
+++ b/src/EasyCaching.InMemory/Internal/InMemoryCaching.cs
@@ -136,7 +136,7 @@
         {
             ArgumentCheck.NotNullOrWhiteSpace(key, nameof(key));
 
-            return _memory.ContainsKey(key);
+            return _memory.TryGetValue(key, out var entry) && entry.ExpiresAt > SystemClock.UtcNow;
         }
 
         public int RemoveAll(IEnumerable<string> keys = null)

--- a/src/EasyCaching.InMemory/Internal/InMemoryCachingOptions.cs
+++ b/src/EasyCaching.InMemory/Internal/InMemoryCachingOptions.cs
@@ -1,0 +1,18 @@
+﻿namespace EasyCaching.InMemory
+{
+    using Microsoft.Extensions.Options;
+    using System;
+
+    public class InMemoryCachingOptions : IOptions<InMemoryCachingOptions>
+    {
+        public TimeSpan ExpirationScanFrequency { get; set; } = TimeSpan.FromMinutes(1);
+
+        public int SizeLimit { get; set; } = 10000;
+
+
+        InMemoryCachingOptions IOptions<InMemoryCachingOptions>.Value
+        {
+            get { return this; }
+        }
+    }
+}

--- a/src/EasyCaching.InMemory/Internal/InternalExt.cs
+++ b/src/EasyCaching.InMemory/Internal/InternalExt.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EasyCaching.InMemory
+{
+    public static class ObjectExtensions
+    {
+        public static DateTimeOffset SafeAdd(this DateTimeOffset date, TimeSpan value)
+        {
+            if (date.Ticks + value.Ticks < DateTimeOffset.MinValue.Ticks)
+                return DateTimeOffset.MinValue;
+
+            if (date.Ticks + value.Ticks > DateTimeOffset.MaxValue.Ticks)
+                return DateTimeOffset.MaxValue;
+
+            return date.Add(value);
+        }
+    }
+
+    internal static class TypeHelper
+    {
+        public static readonly Type ObjectType = typeof(object);
+        public static readonly Type StringType = typeof(string);
+        public static readonly Type CharType = typeof(char);
+        public static readonly Type NullableCharType = typeof(char?);
+        public static readonly Type DateTimeType = typeof(DateTime);
+        public static readonly Type NullableDateTimeType = typeof(DateTime?);
+        public static readonly Type BoolType = typeof(bool);
+        public static readonly Type NullableBoolType = typeof(bool?);
+        public static readonly Type ByteArrayType = typeof(byte[]);
+        public static readonly Type ByteType = typeof(byte);
+        public static readonly Type SByteType = typeof(sbyte);
+        public static readonly Type SingleType = typeof(float);
+        public static readonly Type DecimalType = typeof(decimal);
+        public static readonly Type Int16Type = typeof(short);
+        public static readonly Type UInt16Type = typeof(ushort);
+        public static readonly Type Int32Type = typeof(int);
+        public static readonly Type UInt32Type = typeof(uint);
+        public static readonly Type Int64Type = typeof(long);
+        public static readonly Type UInt64Type = typeof(ulong);
+        public static readonly Type DoubleType = typeof(double);
+
+        public static Type ResolveType(string fullTypeName, Type expectedBase = null)
+        {
+            if (String.IsNullOrEmpty(fullTypeName))
+                return null;
+
+            var type = Type.GetType(fullTypeName);
+            if (type == null)
+            {
+                return null;
+            }
+
+            if (expectedBase != null && !expectedBase.IsAssignableFrom(type))
+            {
+                return null;
+            }
+
+            return type;
+        }
+
+        private static readonly Dictionary<Type, string> _builtInTypeNames = new Dictionary<Type, string> {
+            { StringType, "string" },
+            { BoolType, "bool" },
+            { ByteType, "byte" },
+            { SByteType, "sbyte" },
+            { CharType, "char" },
+            { DecimalType, "decimal" },
+            { DoubleType, "double" },
+            { SingleType, "float" },
+            { Int16Type, "short" },
+            { Int32Type, "int" },
+            { Int64Type, "long" },
+            { ObjectType, "object" },
+            { UInt16Type, "ushort" },
+            { UInt32Type, "uint" },
+            { UInt64Type, "ulong" }
+        };
+    }
+
+    internal static class TypeExtensions
+    {
+        public static bool IsNumeric(this Type type)
+        {
+            if (type.IsArray)
+                return false;
+
+            if (type == TypeHelper.ByteType ||
+                type == TypeHelper.DecimalType ||
+                type == TypeHelper.DoubleType ||
+                type == TypeHelper.Int16Type ||
+                type == TypeHelper.Int32Type ||
+                type == TypeHelper.Int64Type ||
+                type == TypeHelper.SByteType ||
+                type == TypeHelper.SingleType ||
+                type == TypeHelper.UInt16Type ||
+                type == TypeHelper.UInt32Type ||
+                type == TypeHelper.UInt64Type)
+                return true;
+
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Byte:
+                case TypeCode.Decimal:
+                case TypeCode.Double:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                case TypeCode.SByte:
+                case TypeCode.Single:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                    return true;
+            }
+
+            return false;
+        }
+
+        public static bool IsNullableNumeric(this Type type)
+        {
+            if (type.IsArray)
+                return false;
+
+            var t = Nullable.GetUnderlyingType(type);
+            return t != null && t.IsNumeric();
+        }
+    }
+}

--- a/src/EasyCaching.InMemory/Internal/SystemClock.cs
+++ b/src/EasyCaching.InMemory/Internal/SystemClock.cs
@@ -1,0 +1,28 @@
+﻿namespace EasyCaching.InMemory
+{
+    using System;
+
+    internal interface ISystemClock
+    {
+        DateTimeOffset UtcNow();
+    }
+
+    internal class DefaultSystemClock : ISystemClock
+    {
+        public static readonly DefaultSystemClock Instance = new DefaultSystemClock();
+
+        public DateTimeOffset UtcNow() => DateTimeOffset.UtcNow;
+    }
+
+    internal static class SystemClock
+    {
+        private static ISystemClock _instance = DefaultSystemClock.Instance;
+        public static ISystemClock Instance
+        {
+            get => _instance ?? DefaultSystemClock.Instance;
+            set => _instance = value;
+        }
+
+        public static DateTimeOffset UtcNow => Instance.UtcNow();
+    }
+}

--- a/src/EasyCaching.Memcached/DefaultMemcachedCachingProvider.cs
+++ b/src/EasyCaching.Memcached/DefaultMemcachedCachingProvider.cs
@@ -312,7 +312,7 @@
             if (MaxRdSecond > 0)
             {
                 var addSec = new Random().Next(1, MaxRdSecond);
-                expiration.Add(new TimeSpan(0, 0, addSec));
+                expiration = expiration.Add(TimeSpan.FromSeconds(addSec));
             }
 
             _memcachedClient.Store(Enyim.Caching.Memcached.StoreMode.Set, this.HandleCacheKey(cacheKey), cacheValue, expiration);
@@ -335,7 +335,7 @@
             if (MaxRdSecond > 0)
             {
                 var addSec = new Random().Next(1, MaxRdSecond);
-                expiration.Add(new TimeSpan(0, 0, addSec));
+                expiration = expiration.Add(TimeSpan.FromSeconds(addSec));
             }
 
             await _memcachedClient.StoreAsync(Enyim.Caching.Memcached.StoreMode.Set, this.HandleCacheKey(cacheKey), cacheValue, expiration);
@@ -670,7 +670,7 @@
             if (MaxRdSecond > 0)
             {
                 var addSec = new Random().Next(1, MaxRdSecond);
-                expiration.Add(new TimeSpan(0, 0, addSec));
+                expiration = expiration.Add(TimeSpan.FromSeconds(addSec));
             }
 
             return _memcachedClient.Store(Enyim.Caching.Memcached.StoreMode.Add, this.HandleCacheKey(cacheKey), cacheValue, expiration);
@@ -693,7 +693,7 @@
             if (MaxRdSecond > 0)
             {
                 var addSec = new Random().Next(1, MaxRdSecond);
-                expiration.Add(new TimeSpan(0, 0, addSec));
+                expiration = expiration.Add(TimeSpan.FromSeconds(addSec));
             }
 
             return _memcachedClient.StoreAsync(Enyim.Caching.Memcached.StoreMode.Add, this.HandleCacheKey(cacheKey), cacheValue, expiration);

--- a/src/EasyCaching.Redis/Configurations/EasyCachingOptionsExtensions.cs
+++ b/src/EasyCaching.Redis/Configurations/EasyCachingOptionsExtensions.cs
@@ -34,9 +34,9 @@
         /// <param name="options">Options.</param>
         /// <param name="configuration">Configuration.</param>
         /// <param name="name">Name.</param>
-        public static EasyCachingOptions UseRedis(this EasyCachingOptions options, IConfiguration configuration, string name = "")
+        public static EasyCachingOptions UseRedis(this EasyCachingOptions options, IConfiguration configuration, string name = "", string sectionName = EasyCachingConstValue.RedisSection)
         {
-            var dbConfig = configuration.GetSection(EasyCachingConstValue.InMemorySection);
+            var dbConfig = configuration.GetSection(sectionName);
             var redisOptions = new RedisOptions();
             dbConfig.Bind(redisOptions);
 

--- a/src/EasyCaching.Redis/Configurations/RedisDatabaseProvider.cs
+++ b/src/EasyCaching.Redis/Configurations/RedisDatabaseProvider.cs
@@ -80,7 +80,8 @@
                     Ssl = _options.IsSsl,
                     SslHost = _options.SslHost,
                     AllowAdmin = _options.AllowAdmin,
-                    DefaultDatabase = _options.Database
+                    DefaultDatabase = _options.Database,
+                    AbortOnConnectFail = _options.AbortOnConnectFail,
                 };
 
                 foreach (var endpoint in _options.Endpoints)

--- a/src/EasyCaching.Redis/DefaultRedisCachingProvider.cs
+++ b/src/EasyCaching.Redis/DefaultRedisCachingProvider.cs
@@ -175,6 +175,12 @@
             if (_options.EnableLogging)
                 _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
 
+            if (!_cache.StringSet($"{cacheKey}_Lock", 1, TimeSpan.FromMilliseconds(_options.LockMs),When.NotExists))
+            {
+                System.Threading.Thread.Sleep(_options.SleepMs);
+                return Get(cacheKey, dataRetriever, expiration);
+            }
+
             var item = dataRetriever();
             if (item != null)
             {
@@ -216,6 +222,12 @@
 
             if (_options.EnableLogging)
                 _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
+
+            if (!await _cache.StringSetAsync($"{cacheKey}_Lock", 1, TimeSpan.FromMilliseconds(_options.LockMs), When.NotExists))
+            {
+                await Task.Delay(_options.SleepMs);
+                return await GetAsync(cacheKey, dataRetriever, expiration);
+            }
 
             var item = await dataRetriever?.Invoke();
             if (item != null)

--- a/src/EasyCaching.Redis/DefaultRedisCachingProvider.cs
+++ b/src/EasyCaching.Redis/DefaultRedisCachingProvider.cs
@@ -346,7 +346,7 @@
             if (MaxRdSecond > 0)
             {
                 var addSec = new Random().Next(1, MaxRdSecond);
-                expiration.Add(new TimeSpan(0, 0, addSec));
+                expiration = expiration.Add(TimeSpan.FromSeconds(addSec));
             }
 
             _cache.StringSet(
@@ -372,7 +372,7 @@
             if (MaxRdSecond > 0)
             {
                 var addSec = new Random().Next(1, MaxRdSecond);
-                expiration.Add(new TimeSpan(0, 0, addSec));
+                expiration = expiration.Add(TimeSpan.FromSeconds(addSec));
             }
 
             await _cache.StringSetAsync(
@@ -782,7 +782,7 @@
             if (MaxRdSecond > 0)
             {
                 var addSec = new Random().Next(1, MaxRdSecond);
-                expiration.Add(new TimeSpan(0, 0, addSec));
+                expiration = expiration.Add(TimeSpan.FromSeconds(addSec));
             }
 
             return _cache.StringSet(
@@ -810,7 +810,7 @@
             if (MaxRdSecond > 0)
             {
                 var addSec = new Random().Next(1, MaxRdSecond);
-                expiration.Add(new TimeSpan(0, 0, addSec));
+                expiration = expiration.Add(TimeSpan.FromSeconds(addSec));
             }
 
             return _cache.StringSetAsync(

--- a/test/EasyCaching.PerformanceTests/EasyCaching.PerformanceTests.csproj
+++ b/test/EasyCaching.PerformanceTests/EasyCaching.PerformanceTests.csproj
@@ -6,8 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />    
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />    
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
   </ItemGroup>
 
    <ItemGroup>

--- a/test/EasyCaching.PerformanceTests/MemoryCacheBenchmark.cs
+++ b/test/EasyCaching.PerformanceTests/MemoryCacheBenchmark.cs
@@ -1,0 +1,58 @@
+﻿namespace EasyCaching.PerformanceTests
+{
+    using BenchmarkDotNet.Attributes;
+    using EasyCaching.InMemory;
+    using Microsoft.Extensions.Caching.Memory;
+
+    [MemoryDiagnoser]
+    [AllStatisticsColumn]
+    public class SetBenchmark
+    {
+        private readonly MemoryCache _msCache = new MemoryCache(new MemoryCacheOptions());
+        private readonly InMemoryCaching _cache = new InMemoryCaching(new InMemoryCachingOptions());
+
+        [Benchmark]
+        public void MS()
+        {
+            _msCache.Set("ms-key", "ms-value", System.TimeSpan.FromSeconds(5));
+        }
+
+        [Benchmark]
+        public void EC()
+        {
+            _cache.Set("ec-key", "ec-value", System.TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [MemoryDiagnoser]
+    [AllStatisticsColumn]
+    public class GetBenchmark
+    {
+        private readonly MemoryCache _msCache = new MemoryCache(new MemoryCacheOptions());
+        private readonly InMemoryCaching _cache = new InMemoryCaching(new InMemoryCachingOptions());
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                _msCache.Set($"ms-key-{i}", $"ms-value-{i}", System.TimeSpan.FromSeconds(5));
+                _cache.Set($"ec-key-{i}", $"ec-value-{i}", System.TimeSpan.FromSeconds(5));
+            }
+        }
+
+        [Benchmark]
+        public void MS()
+        {
+            var i = new System.Random().Next(0, 1000);
+            _msCache.Get($"ms-key-{i}");
+        }
+
+        [Benchmark]
+        public void EC()
+        {
+            var i = new System.Random().Next(0, 1000);
+            _cache.Get<string>($"ec-key-{i}");
+        }
+    }
+}

--- a/test/EasyCaching.PerformanceTests/Program.cs
+++ b/test/EasyCaching.PerformanceTests/Program.cs
@@ -6,10 +6,12 @@
     {
         static void Main(string[] args)
         {
-            BenchmarkRunner.Run<SerializeSingleObject2BytesBenchmark>();
-            BenchmarkRunner.Run<SerializeMultiObject2BytesBenchmark>();
-            BenchmarkRunner.Run<SerializerSingleObject2ArraySegmentBenchmark>();
-            BenchmarkRunner.Run<SerializerMultiObject2ArraySegmentBenchmark>();
+            //BenchmarkRunner.Run<SerializeSingleObject2BytesBenchmark>();
+            //BenchmarkRunner.Run<SerializeMultiObject2BytesBenchmark>();
+            //BenchmarkRunner.Run<SerializerSingleObject2ArraySegmentBenchmark>();
+            //BenchmarkRunner.Run<SerializerMultiObject2ArraySegmentBenchmark>();
+            BenchmarkRunner.Run<SetBenchmark>();
+            BenchmarkRunner.Run<GetBenchmark>();
         }
     }
 }

--- a/test/EasyCaching.PerformanceTests/SerializerBenchmark.cs
+++ b/test/EasyCaching.PerformanceTests/SerializerBenchmark.cs
@@ -1,8 +1,6 @@
 ﻿namespace EasyCaching.PerformanceTests
 {
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Columns;
-    using BenchmarkDotNet.Running;
     using EasyCaching.Core;
     using EasyCaching.Serialization.Json;
     using EasyCaching.Serialization.MessagePack;

--- a/test/EasyCaching.UnitTests/CachingTests/BaseCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/BaseCachingProviderTest.cs
@@ -718,7 +718,7 @@
             var flag = await _provider.ExistsAsync(cacheKey);
 
             Assert.False(flag);
-        }
+        }              
         #endregion
 
         #region RemoveByPrefix/RemoveByPrefixAsync

--- a/test/EasyCaching.UnitTests/CachingTests/BaseCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/BaseCachingProviderTest.cs
@@ -576,19 +576,19 @@
         }
 
         [Fact]
-        protected virtual void GetAsync_Parallel_Should_Succeed()
+        protected virtual async Task GetAsync_Parallel_Should_Succeed()
         {
             var cacheKey = Guid.NewGuid().ToString();
             int count = 0;
 
-            Parallel.For(0, 20, async x =>
-            {
-                await _provider.GetAsync(cacheKey, async () =>
-                {
-                    count++;
-                    return await Task.FromResult(1);
-                }, _defaultTs);
-            });
+            var tasks = Enumerable.Range(0, 20)
+                        .Select(i => _provider.GetAsync(cacheKey, () =>
+                        {
+                            count++;
+                            return Task.FromResult(1);
+                        }, _defaultTs));
+
+            await Task.WhenAll(tasks);
 
             Assert.Equal(1, count);
         }

--- a/test/EasyCaching.UnitTests/CachingTests/BaseCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/BaseCachingProviderTest.cs
@@ -556,6 +556,42 @@
             Assert.Equal(default(string), val.Value);
         }
 
+        [Fact]
+        protected virtual void Get_Parallel_Should_Succeed()
+        {
+            var cacheKey = Guid.NewGuid().ToString();
+
+            int count = 0;
+
+            Parallel.For(0, 20, x =>
+            {
+                _provider.Get<int>(cacheKey, () =>
+                {
+                    count++;
+                    return 1;
+                }, _defaultTs);
+            });
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        protected virtual void GetAsync_Parallel_Should_Succeed()
+        {
+            var cacheKey = Guid.NewGuid().ToString();
+            int count = 0;
+
+            Parallel.For(0, 20, async x =>
+            {
+                await _provider.GetAsync(cacheKey, async () =>
+                {
+                    count++;
+                    return await Task.FromResult(1);
+                }, _defaultTs);
+            });
+
+            Assert.Equal(1, count);
+        }
         #endregion
 
         #region Refresh/RefreshAsync

--- a/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
@@ -75,5 +75,17 @@
         {
             await Task.FromResult(1);
         }
+
+        [Fact]
+        protected override void Get_Parallel_Should_Succeed()
+        {
+
+        }
+
+        [Fact]
+        protected override void GetAsync_Parallel_Should_Succeed()
+        {
+
+        }
     }
 }

--- a/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
@@ -32,7 +32,7 @@
 
             var providers = new List<IEasyCachingProvider>
             {
-                new DefaultInMemoryCachingProvider(new MemoryCache(new MemoryCacheOptions()), new TestOptionMonitorWrapper<InMemoryOptions>(new InMemoryOptions())),
+                new DefaultInMemoryCachingProvider(new InMemory.InMemoryCaching(new InMemoryCachingOptions()), new TestOptionMonitorWrapper<InMemoryOptions>(new InMemoryOptions())),
                 new DefaultRedisCachingProvider(fakeDbProvider, serializer, new TestOptionMonitorWrapper<RedisOptions>(new RedisOptions()))
             };
 
@@ -55,7 +55,7 @@
         [Fact]
         protected override void OnHit_Should_Return_One_And_OnMiss_Should_Return_Zero()
         {
-            
+
         }
 
         [Fact]
@@ -67,7 +67,7 @@
         [Fact]
         protected override void TrySet_Value_And_Get_Cached_Value_Should_Succeed()
         {
-            
+
         }
 
         [Fact]

--- a/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
@@ -83,9 +83,9 @@
         }
 
         [Fact]
-        protected override void GetAsync_Parallel_Should_Succeed()
+        protected override Task GetAsync_Parallel_Should_Succeed()
         {
-
+            return Task.FromResult(1);
         }
     }
 }

--- a/test/EasyCaching.UnitTests/CachingTests/MemoryCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/MemoryCachingProviderTest.cs
@@ -27,6 +27,21 @@ namespace EasyCaching.UnitTests
         {
             Assert.Equal(120, _provider.MaxRdSecond);
         }
+
+
+        [Fact]
+        public void TrySet_Parallel_Should_Succeed()
+        {
+            var list = new List<bool>();
+
+            Parallel.For(1, 20, x =>
+            {
+                list.Add(_provider.TrySet<int>("Parallel", 1, TimeSpan.FromSeconds(1)));
+            });
+
+            Assert.Equal(1, list.Count(x => x));
+
+        }
     }
 
     public class MemoryCachingProviderWithFactoryTest : BaseCachingProviderWithFactoryTest
@@ -144,6 +159,9 @@ namespace EasyCaching.UnitTests
             'CachingProviderType': 1,
             'MaxRdSecond': 600,
             'Order': 99,
+            'dbconfig': {      
+                'SizeLimit' :  50
+            }
         }
     }
 }";

--- a/test/EasyCaching.UnitTests/CachingTests/MemoryCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/MemoryCachingProviderTest.cs
@@ -42,6 +42,18 @@ namespace EasyCaching.UnitTests
             Assert.Equal(1, list.Count(x => x));
 
         }
+
+        [Fact]
+        public void Exists_After_Expiration_Should_Return_False()
+        {
+            var cacheKey = Guid.NewGuid().ToString();
+            var cacheValue = "value";
+            _provider.Set(cacheKey, cacheValue, TimeSpan.FromMilliseconds(200));
+            System.Threading.Thread.Sleep(300);
+            var flag = _provider.Exists(cacheKey);
+
+            Assert.False(flag);
+        }
     }
 
     public class MemoryCachingProviderWithFactoryTest : BaseCachingProviderWithFactoryTest

--- a/test/EasyCaching.UnitTests/CachingTests/MemoryCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/MemoryCachingProviderTest.cs
@@ -57,42 +57,6 @@ namespace EasyCaching.UnitTests
 
             Assert.False(flag);
         }
-
-
-        [Fact]
-        public void Get_Parallel_Should_Succeed()
-        {
-            int count = 0;
-
-            Parallel.For(0, 20, x =>
-            {
-                _provider.Get<int>("Parallel_GET", ()=> 
-                {
-                    count++;
-                    return 1;
-                }, _defaultTs);
-            });
-
-            Assert.Equal(1, count);
-        }
-
-        [Fact]
-        public void GetAsync_Parallel_Should_Succeed()
-        {
-            int count = 0;
-
-            Parallel.For(0, 20, async x =>
-            {
-                await _provider.GetAsync("Parallel_GET", async () =>
-                {
-                    count++;
-                    return await Task.FromResult(1);
-                }, _defaultTs);
-            });
-
-            Assert.Equal(1, count);
-        }
-
     }
 
     public class MemoryCachingProviderWithFactoryTest : BaseCachingProviderWithFactoryTest

--- a/test/EasyCaching.UnitTests/CachingTests/RedisCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/RedisCachingProviderTest.cs
@@ -86,12 +86,8 @@ namespace EasyCaching.UnitTests
     }
 
 
-    public class RedisCachingProviderWithFactoryTest : BaseCachingProviderTest
-    {
-        private readonly IEasyCachingProvider _secondProvider;
-
-        private const string SECOND_PROVIDER_NAME = "second";
-
+    public class RedisCachingProviderWithFactoryTest : BaseCachingProviderWithFactoryTest
+    {       
         public RedisCachingProviderWithFactoryTest()
         {
             IServiceCollection services = new ServiceCollection();
@@ -118,31 +114,6 @@ namespace EasyCaching.UnitTests
             _provider = factory.GetCachingProvider(EasyCachingConstValue.DefaultRedisName);
             _secondProvider = factory.GetCachingProvider(SECOND_PROVIDER_NAME);
             _defaultTs = TimeSpan.FromSeconds(30);
-        }
-
-        [Fact]
-        public void Multi_Instance_Set_And_Get_Should_Succeed()
-        {
-            var cacheKey1 = "named-provider-1";
-            var cacheKey2 = "named-provider-2";
-
-            var value1 = Guid.NewGuid().ToString();
-            var value2 = Guid.NewGuid().ToString("N");
-
-            _provider.Set(cacheKey1, value1, _defaultTs);
-            _secondProvider.Set(cacheKey2, value2, _defaultTs);
-
-            var p1 = _provider.Get<string>(cacheKey1);
-            var p2 = _provider.Get<string>(cacheKey2);
-
-            var s1 = _secondProvider.Get<string>(cacheKey1);
-            var s2 = _secondProvider.Get<string>(cacheKey2);
-
-            Assert.Equal(value1, p1.Value);
-            Assert.False(p2.HasValue);
-
-            Assert.False(s1.HasValue);
-            Assert.Equal(value2, s2.Value);
         }
     }
 }

--- a/test/EasyCaching.UnitTests/CachingTests/SQLiteCachingTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/SQLiteCachingTest.cs
@@ -40,6 +40,18 @@
             _provider = new DefaultSQLiteCachingProvider(_dbProvider, new TestOptionMonitorWrapper<SQLiteOptions>(new SQLiteOptions()));
             _defaultTs = TimeSpan.FromSeconds(30);
         }
+
+        [Fact]
+        protected override void GetAsync_Parallel_Should_Succeed()
+        {
+
+        }
+
+        [Fact]
+        protected override void Get_Parallel_Should_Succeed()
+        {
+
+        }
     }
 
 

--- a/test/EasyCaching.UnitTests/CachingTests/SQLiteCachingTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/SQLiteCachingTest.cs
@@ -42,9 +42,10 @@
         }
 
         [Fact]
-        protected override void GetAsync_Parallel_Should_Succeed()
+        protected override Task  GetAsync_Parallel_Should_Succeed()
         {
-
+            return Task.FromResult(1);
+                
         }
 
         [Fact]

--- a/test/EasyCaching.UnitTests/InterceptorTests/AspectCoreInterceptorTest.cs
+++ b/test/EasyCaching.UnitTests/InterceptorTests/AspectCoreInterceptorTest.cs
@@ -175,7 +175,10 @@ namespace EasyCaching.UnitTests
         {
             IServiceCollection services = new ServiceCollection();
             services.AddTransient<IAspectCoreExampleService, AspectCoreExampleService>();
-            services.AddDefaultInMemoryCache();
+            services.AddDefaultInMemoryCache(x =>
+            {
+                x.MaxRdSecond = 0;
+            });
             IServiceProvider serviceProvider = services.ConfigureAspectCoreInterceptor();
 
             _cachingProvider = serviceProvider.GetService<IEasyCachingProvider>();

--- a/test/EasyCaching.UnitTests/InterceptorTests/CastleInterceptorTest.cs
+++ b/test/EasyCaching.UnitTests/InterceptorTests/CastleInterceptorTest.cs
@@ -181,7 +181,10 @@ namespace EasyCaching.UnitTests
         {
             IServiceCollection services = new ServiceCollection();
             services.AddTransient<ICastleExampleService, CastleExampleService>();
-            services.AddDefaultInMemoryCache();
+            services.AddDefaultInMemoryCache(x=> 
+            {
+                x.MaxRdSecond = 0;
+            });
             IServiceProvider serviceProvider = services.ConfigureCastleInterceptor();
 
             _cachingProvider = serviceProvider.GetService<IEasyCachingProvider>();
@@ -198,7 +201,10 @@ namespace EasyCaching.UnitTests
         {
             IServiceCollection services = new ServiceCollection();
             services.AddTransient<IAspectCoreExampleService, AspectCoreExampleService>();
-            services.AddDefaultInMemoryCache();
+            services.AddDefaultInMemoryCache(x =>
+            {
+                x.MaxRdSecond = 0;
+            });
 
             Action<ContainerBuilder> action = x =>
             {
@@ -229,7 +235,10 @@ namespace EasyCaching.UnitTests
         {
             IServiceCollection services = new ServiceCollection();
             services.AddTransient<IAspectCoreExampleService, AspectCoreExampleService>();
-            services.AddDefaultInMemoryCache();
+            services.AddDefaultInMemoryCache(x =>
+            {
+                x.MaxRdSecond = 0;
+            });
 
             Action<ContainerBuilder> action = x =>
             {


### PR DESCRIPTION
This PR contains the following changes.

- [x]   Redesign InMemoryCaching
- [x]   (InMemory)Add mutex key of  Get/GetAsync with data retriever
- [x]   (Redis)Add mutex key of  Get/GetAsync with data retriever
- [x]   (Memcached)Add mutex key of  Get/GetAsync with data retriever
- [ ]   (SQLite)Add mutex key of  Get/GetAsync with data retriever
- [ ]   (Hybird)Add mutex key of  Get/GetAsync with data retriever
