### PR TITLE
Fixed some bugs of Interceptor.AspectCore and Interceptor.Castle

### DIFF
--- a/sample/EasyCaching.Demo.Interceptors/Controllers/ValuesController.cs
+++ b/sample/EasyCaching.Demo.Interceptors/Controllers/ValuesController.cs
@@ -57,6 +57,11 @@
                 var res = await _aService.GetDemoAsync(999);
                 return $"{res.Id}-{res.Name}-{res.CreateTime}";
             }
+            else if (type == 3)
+            {
+                var res = await _aService.GetDemoListAsync(999);
+                return $"{res.Count}";
+            }
             else
             {
                 return await Task.FromResult("wait");
@@ -103,6 +108,11 @@
             {
                 var res = await _cService.GetDemoAsync(999);
                 return $"{res.Id}-{res.Name}-{res.CreateTime}";
+            }
+            else if (type == 3)
+            {
+                var res = await _aService.GetDemoListAsync(999);
+                return $"{res.Count}";
             }
             else
             {

--- a/sample/EasyCaching.Demo.Interceptors/Services/IAspectCoreService.cs
+++ b/sample/EasyCaching.Demo.Interceptors/Services/IAspectCoreService.cs
@@ -22,6 +22,10 @@
         Task<Demo> GetDemoAsync(int id);
 
         [EasyCachingAble(Expiration = 10)]
+        Task<System.Collections.Generic.List<Demo>> GetDemoListAsync(int id);
+        
+
+        [EasyCachingAble(Expiration = 10)]
         Demo GetDemo(int id);
     }
 
@@ -47,9 +51,19 @@
             return Task.FromResult(new Demo { Id = id, CreateTime = System.DateTime.Now, Name = "catcher" });
         }
 
+        public Task<System.Collections.Generic.List<Demo>> GetDemoListAsync(int id)
+        {
+            return Task.FromResult(new System.Collections.Generic.List<Demo>() { new Demo { Id = id, CreateTime = System.DateTime.Now, Name = "catcher" } });
+        }
+
         public async Task<string> GetUtcTimeAsync()
         {
             return await Task.FromResult<string>(System.DateTimeOffset.UtcNow.ToString());
+        }
+
+        public async Task DeleteSomethingAsync(int id)
+        {
+            await Task.Run(() => System.Console.WriteLine("Handle delete something.."));
         }
 
         public string PutSomething(string str)

--- a/sample/EasyCaching.Demo.Interceptors/Services/ICastleService.cs
+++ b/sample/EasyCaching.Demo.Interceptors/Services/ICastleService.cs
@@ -22,6 +22,9 @@
         Task<Demo> GetDemoAsync(int id);
 
         [EasyCachingAble(Expiration = 10)]
+        Task<System.Collections.Generic.List<Demo>> GetDemoListAsync(int id);
+
+        [EasyCachingAble(Expiration = 10)]
         Demo GetDemo(int id);
     }
 
@@ -45,6 +48,11 @@
         public Task<Demo> GetDemoAsync(int id)
         {
             return Task.FromResult(new Demo { Id = id, CreateTime = System.DateTime.Now, Name = "catcher" });
+        }
+
+        public Task<System.Collections.Generic.List<Demo>> GetDemoListAsync(int id)
+        {
+            return Task.FromResult(new System.Collections.Generic.List<Demo>() { new Demo { Id = id, CreateTime = System.DateTime.Now, Name = "catcher" } });
         }
 
         public async Task<string> GetUtcTimeAsync()

--- a/src/EasyCaching.Interceptor.AspectCore/EasyCachingInterceptor.cs
+++ b/src/EasyCaching.Interceptor.AspectCore/EasyCachingInterceptor.cs
@@ -66,12 +66,13 @@
         {
             if (context.ServiceMethod.GetCustomAttributes(true).FirstOrDefault(x => x.GetType() == typeof(EasyCachingAbleAttribute)) is EasyCachingAbleAttribute attribute)
             {
-                var cacheKey = KeyGenerator.GetCacheKey(context.ServiceMethod, context.Parameters, attribute.CacheKeyPrefix);
-                var cacheValue = await CacheProvider.GetAsync(cacheKey, context.ServiceMethod.ReturnType);
-
                 var returnType = context.IsAsync()
                         ? context.ServiceMethod.ReturnType.GetGenericArguments().First()
                         : context.ServiceMethod.ReturnType;
+
+                var cacheKey = KeyGenerator.GetCacheKey(context.ServiceMethod, context.Parameters, attribute.CacheKeyPrefix);
+
+                object cacheValue = await CacheProvider.GetAsync(cacheKey, returnType);
 
                 if (cacheValue != null)
                 {

--- a/src/EasyCaching.Interceptor.Castle/EasyCaching.Interceptor.Castle.csproj
+++ b/src/EasyCaching.Interceptor.Castle/EasyCaching.Interceptor.Castle.csproj
@@ -28,5 +28,6 @@
     <PackageReference Include="Autofac.Extras.DynamicProxy" Version="4.5.0" />
     <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.1" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/EasyCaching.Interceptor.Castle/ReflectionExtensions.cs
+++ b/src/EasyCaching.Interceptor.Castle/ReflectionExtensions.cs
@@ -1,0 +1,95 @@
+﻿using Castle.DynamicProxy;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EasyCaching.Interceptor.Castle
+{
+    public static class ReflectionExtensions
+    {
+        public static bool IsReturnTask(this MethodInfo methodInfo)
+        {
+            if (methodInfo == null)
+            {
+                throw new ArgumentNullException(nameof(methodInfo));
+            }
+            var returnType = methodInfo.ReturnType.GetTypeInfo();
+            return returnType.IsTaskWithResult();
+        }
+
+        public static Task<object> UnwrapAsyncReturnValue(this IInvocation invocation)
+        {
+            if (invocation == null)
+            {
+                throw new ArgumentNullException(nameof(invocation));
+            }
+
+            var serviceMethod = invocation.Method ?? invocation.MethodInvocationTarget;
+
+            if (!serviceMethod.IsReturnTask())
+            {
+                throw new InvalidOperationException("This operation only support asynchronous method.");
+            }
+
+            var returnValue = invocation.ReturnValue;
+            if (returnValue == null)
+            {
+                return null;
+            }
+
+            var returnTypeInfo = returnValue.GetType().GetTypeInfo();
+            return Unwrap(returnValue, returnTypeInfo);
+        }
+
+        private static async Task<object> Unwrap(object value, TypeInfo valueTypeInfo)
+        {
+            object result = null;
+
+            if (valueTypeInfo.IsTaskWithResult())
+            {
+                // Is there better solution to unwrap ?
+                result = (object) (await (dynamic) value);
+            }
+            else if (value is Task)
+            {
+                return null;
+            }
+            else
+            {
+                result = value;
+            }
+
+            if (result == null)
+            {
+                return null;
+            }
+
+            var resultTypeInfo = result.GetType().GetTypeInfo();
+            if (IsAsyncType(resultTypeInfo))
+            {
+                return Unwrap(result, resultTypeInfo);
+            }
+
+            return result;
+        }
+
+        private static bool IsAsyncType(TypeInfo typeInfo)
+        {
+            if (typeInfo.IsTask())
+            {
+                return true;
+            }
+
+            if (typeInfo.IsTaskWithResult())
+            {
+                return true;
+            }
+            
+
+            return false;
+        }
+    }
+}

--- a/src/EasyCaching.Interceptor.Castle/TypeExtensions.cs
+++ b/src/EasyCaching.Interceptor.Castle/TypeExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace EasyCaching.Interceptor.Castle
+{
+    public static class TypeExtensions
+    {
+        private static readonly ConcurrentDictionary<TypeInfo, bool> isTaskOfTCache = new ConcurrentDictionary<TypeInfo, bool>();
+
+        public static bool IsTaskWithResult(this TypeInfo typeInfo)
+        {
+            if (typeInfo == null)
+            {
+                throw new ArgumentNullException(nameof(typeInfo));
+            }
+            return isTaskOfTCache.GetOrAdd(typeInfo, Info => Info.IsGenericType && typeof(Task).GetTypeInfo().IsAssignableFrom(Info));
+        }
+
+        public static bool IsTask(this TypeInfo typeInfo)
+        {
+            if (typeInfo == null)
+            {
+                throw new ArgumentNullException(nameof(typeInfo));
+            }
+            return typeInfo.AsType() == typeof(Task);
+        }
+        
+    }
+}

--- a/test/EasyCaching.UnitTests/InterceptorTests/CastleInterceptorTest.cs
+++ b/test/EasyCaching.UnitTests/InterceptorTests/CastleInterceptorTest.cs
@@ -144,10 +144,10 @@ namespace EasyCaching.UnitTests
 
             var key = _keyGenerator.GetCacheKey(method, new object[] { 1, "123" }, "CastleExample");
 
-            var value = _cachingProvider.Get<Task<string>>(key);
+            var value = _cachingProvider.Get<string>(key);
 
             Assert.True(value.HasValue);
-            Assert.Equal(str, value.Value.Result);
+            Assert.Equal(str, value.Value);
         }
 
         [Fact]


### PR DESCRIPTION
## 更改目的
- 修复Interceptor.AspectCore和Interceptor.Castle在Task返回时，缓存中存储的值为T，而serviceMethod.ReturnType的值为Task<T>，导致反序列化时出现异常。
- 在Interceptor.Castle中参考AspectCore的源码加入ReflectionExtensions和TypeExtensions用于IsReturnTask和UnwrapAsyncReturnValue
```C#
//判断是否异步
serviceMethod.IsReturnTask()

//获取Task<T>中的T
invocation.UnwrapAsyncReturnValue()
```
