### PR TITLE
Interceptor should generate valid cache key for basic type parameters

### DIFF
--- a/src/EasyCaching.Core/Interceptor/DefaultEasyCachingKeyGenerator.cs
+++ b/src/EasyCaching.Core/Interceptor/DefaultEasyCachingKeyGenerator.cs
@@ -1,6 +1,5 @@
 ﻿namespace EasyCaching.Core.Interceptor
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
@@ -11,132 +10,34 @@
     /// </summary>
     public class DefaultEasyCachingKeyGenerator : IEasyCachingKeyGenerator
     {
-        /// <summary>
-        /// The link char of cache key.
-        /// </summary>
-        private char _linkChar = ':';
+        private const char LinkChar = ':';
 
-        /// <summary>
-        /// Gets the cache key.
-        /// </summary>
-        /// <returns>The cache key.</returns>
-        /// <param name="methodInfo">Method info.</param>
-        /// <param name="args">Arguments.</param>
-        /// <param name="prefix">Prefix.</param>
         public string GetCacheKey(MethodInfo methodInfo, object[] args, string prefix)
         {
-            if(string.IsNullOrWhiteSpace(prefix))
-            {
-                var typeName = methodInfo.DeclaringType.Name;
-                var methodName = methodInfo.Name;
-
-                var methodArguments = this.FormatArgumentsToPartOfCacheKey(args);
-
-                return this.GenerateCacheKey(typeName, methodName, methodArguments);
-            }
-            else
-            {                
-                var methodArguments = this.FormatArgumentsToPartOfCacheKey(args);
-
-                return this.GenerateCacheKey(string.Empty, prefix, methodArguments);
-            }
+            var methodArguments = args?.Any() == true
+                                      ? args.Select(ParameterCacheKeys.GenerateCacheKey)
+                                      : new[] { "0" };
+            return GenerateCacheKey(methodInfo, prefix, methodArguments);
         }
 
-        /// <summary>
-        /// Gets the cache key prefix.
-        /// </summary>
-        /// <returns>The cache key prefix.</returns>
-        /// <param name="methodInfo">Method info.</param>
-        /// <param name="prefix">Prefix.</param>
         public string GetCacheKeyPrefix(MethodInfo methodInfo, string prefix)
         {
-            if (string.IsNullOrWhiteSpace(prefix))
-            {
-                var typeName = methodInfo.DeclaringType.Name;
-                var methodName = methodInfo.Name;
+            if (!string.IsNullOrWhiteSpace(prefix)) return $"{prefix}{LinkChar}";
 
-                return this.GenerateCacheKeyPrefix(typeName, methodName);
-            }
-            else
-            {                
-                return this.GenerateCacheKeyPrefix(string.Empty, prefix);
-            }
+            var typeName = methodInfo.DeclaringType?.Name;
+            var methodName = methodInfo.Name;
+
+            return $"{typeName}{LinkChar}{methodName}{LinkChar}";
         }
 
-        /// <summary>
-        /// Generates the cache key prefix.
-        /// </summary>
-        /// <returns>The cache key prefix.</returns>
-        /// <param name="first">First.</param>
-        /// <param name="second">Second.</param>
-        private string GenerateCacheKeyPrefix(string first, string second)
-        {            
-            return string.Concat(first,_linkChar,second,_linkChar).TrimStart(_linkChar);                       
-        }
-
-        /// <summary>
-        /// Formats the arguments to part of cache key.
-        /// </summary>
-        /// <returns>The arguments to part of cache key.</returns>
-        /// <param name="methodArguments">Method arguments.</param>
-        private IList<string> FormatArgumentsToPartOfCacheKey(object[] methodArguments)
+        private string GenerateCacheKey(MethodInfo methodInfo, string prefix, IEnumerable<string> parameters)
         {
-            if(methodArguments!=null && methodArguments.Length > 0)
-            {
-                return methodArguments.Select(this.GetArgumentValue).ToList();    
-            }
-            else
-            {
-                return new List<string> { "0" };
-            }
-        }
+            var cacheKeyPrefix = GetCacheKeyPrefix(methodInfo, prefix);
 
-        /// <summary>
-        /// Generates the cache key.
-        /// </summary>
-        /// <returns>The cache key.</returns>
-        /// <param name="typeName">Type name.</param>
-        /// <param name="methodName">Method name.</param>
-        /// <param name="parameters">Parameters.</param>
-        private string GenerateCacheKey(string typeName, string methodName, IList<string> parameters)
-        {
             var builder = new StringBuilder();
-
-            builder.Append(this.GenerateCacheKeyPrefix(typeName,methodName));
-
-            foreach (var param in parameters)
-            {
-                builder.Append(param);
-                builder.Append(_linkChar);
-            }
-
-            var str = builder.ToString().TrimEnd(_linkChar);
-
-            return str;
-            //using (SHA1 sha1 = SHA1.Create())
-            //{
-            //    byte[] data = sha1.ComputeHash(Encoding.UTF8.GetBytes(str));
-            //    return Convert.ToBase64String(data, Base64FormattingOptions.None);
-            //}
-        }
-
-        /// <summary>
-        /// Gets the argument value.
-        /// </summary>
-        /// <returns>The argument value.</returns>
-        /// <param name="arg">Argument.</param>
-        private string GetArgumentValue(object arg)
-        {
-            if (arg is int || arg is long || arg is string)
-                return arg.ToString();
-
-            if (arg is DateTime)
-                return ((DateTime)arg).ToString("yyyyMMddHHmmss");
-
-            if (arg is ICachable)
-                return ((ICachable)arg).CacheKey;
-
-            return null;
+            builder.Append(cacheKeyPrefix);
+            builder.Append(string.Join(LinkChar.ToString(), parameters));
+            return builder.ToString();
         }
     }
 }

--- a/src/EasyCaching.Core/Interceptor/ParameterCacheKeys.cs
+++ b/src/EasyCaching.Core/Interceptor/ParameterCacheKeys.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EasyCaching.Core.Interceptor
+{
+    public static class ParameterCacheKeys
+    {
+        public static string GenerateCacheKey(object parameter)
+        {
+            if (parameter == null) return string.Empty;
+            if (parameter is ICachable cachable) return cachable.CacheKey;
+            if (parameter is string key) return key;
+            if (parameter is DateTime dateTime) return dateTime.ToString("O");
+            if (parameter is DateTimeOffset dateTimeOffset) return dateTimeOffset.ToString("O");
+            if (parameter is IEnumerable enumerable) return GenerateCacheKey(enumerable.Cast<object>());
+            return parameter.ToString();
+        }
+
+        private static string GenerateCacheKey(IEnumerable<object> parameter)
+        {
+            if (parameter == null) return string.Empty;
+            return "[" + string.Join(",", parameter) + "]";
+        }
+    }
+}

--- a/test/EasyCaching.UnitTests/Core/DefaultEasyCachingKeyGeneratorTest.cs
+++ b/test/EasyCaching.UnitTests/Core/DefaultEasyCachingKeyGeneratorTest.cs
@@ -72,6 +72,18 @@
         }
 
         [Fact]
+        public void Generate_CacheKey_With_Guid_Param_Method_Should_Succeed()
+        {
+            var methodName = "Method3";
+            MethodInfo methodInfo = typeof(Demo).GetMethod(methodName);
+
+            var newGuid = Guid.NewGuid();
+            var key = _keyGenerator.GetCacheKey(methodInfo, new object[] { newGuid }, string.Empty);
+
+            Assert.Equal($"Demo:Method3:{newGuid.ToString()}", key);
+        }
+
+        [Fact]
         public void Generate_CacheKey_With_String_Param_And_Prefix_Method_Should_Succeed()
         {
             var methodName = "Method3";
@@ -88,9 +100,10 @@
             var methodName = "Method4";
             MethodInfo methodInfo = typeof(Demo).GetMethod(methodName);
 
-            var key = _keyGenerator.GetCacheKey(methodInfo, null, string.Empty);
+            var dateTime = DateTime.Now;
+            var key = _keyGenerator.GetCacheKey(methodInfo, new object[] { dateTime }, string.Empty);
 
-            Assert.Equal($"Demo:Method4:0", key);
+            Assert.Equal($"Demo:Method4:{dateTime:O}", key);
         }
 
         [Fact]
@@ -99,9 +112,58 @@
             var methodName = "Method4";
             MethodInfo methodInfo = typeof(Demo).GetMethod(methodName);
 
-            var key = _keyGenerator.GetCacheKey(methodInfo, null, "GenKey");
+            var dateTime = DateTime.Now;
+            var key = _keyGenerator.GetCacheKey(methodInfo, new object[] { dateTime }, "GenKey");
 
-            Assert.Equal($"GenKey:0", key);
+            Assert.Equal($"GenKey:{dateTime:O}", key);
+        }
+
+        [Fact]
+        public void Generate_CacheKey_With_DateTimeOffset_Param_Method_Should_Succeed()
+        {
+            var methodName = "Method4";
+            MethodInfo methodInfo = typeof(Demo).GetMethod(methodName);
+
+            var dateTime = DateTimeOffset.Now;
+            var key = _keyGenerator.GetCacheKey(methodInfo, new object[] { dateTime }, string.Empty);
+
+            Assert.Equal($"Demo:Method4:{dateTime:O}", key);
+        }
+
+        [Fact]
+        public void Generate_CacheKey_With_DateTimeOffset_Param_And_Prefix_Method_Should_Succeed()
+        {
+            var methodName = "Method4";
+            MethodInfo methodInfo = typeof(Demo).GetMethod(methodName);
+
+            var dateTime = DateTimeOffset.Now;
+            var key = _keyGenerator.GetCacheKey(methodInfo, new object[] { dateTime }, "GenKey");
+
+            Assert.Equal($"GenKey:{dateTime:O}", key);
+        }
+
+        [Fact]
+        public void Generate_CacheKey_With_Array_Param_Method_Should_Succeed()
+        {
+            var methodName = "Method4";
+            MethodInfo methodInfo = typeof(Demo).GetMethod(methodName);
+
+            var array = new[] { 1, 2, 3 };
+            var key = _keyGenerator.GetCacheKey(methodInfo, new object[] { array }, string.Empty);
+
+            Assert.Equal($"Demo:Method4:[1,2,3]", key);
+        }
+
+        [Fact]
+        public void Generate_CacheKey_With_Array_Param_And_Prefix_Method_Should_Succeed()
+        {
+            var methodName = "Method4";
+            MethodInfo methodInfo = typeof(Demo).GetMethod(methodName);
+
+            var array = new[] { 1, 2, 3 };
+            var key = _keyGenerator.GetCacheKey(methodInfo, new object[] { array }, "GenKey");
+
+            Assert.Equal($"GenKey:[1,2,3]", key);
         }
 
         [Fact]


### PR DESCRIPTION
Hi @catcherwong ,

I've created this PR against dev instead of https://github.com/dotnetcore/EasyCaching/pull/86. Please take a look.

Interceptor respects only int, long, string, DateTime (in a weird way though), and ignores other primitive types e.g. Guid, decimal, DateTimeOffset etc.

Thus, if we cache a method with a guid parameter, we'll aways hit cache no matter what parameter is passed.

This PR changes DefaultEasyCachingKeyGenerator so that it respects simple types, arrays and types with proper ToString method.