### PR TITLE
Make caching interceptor support subclass of easycaching attributes.

### DIFF
--- a/src/EasyCaching.Interceptor.AspectCore/EasyCachingInterceptor.cs
+++ b/src/EasyCaching.Interceptor.AspectCore/EasyCachingInterceptor.cs
@@ -97,19 +97,19 @@
         /// <param name="next">Next.</param>
         private async Task ProceedAbleAsync(AspectContext context, AspectDelegate next)
         {
-            if (GetMethodAttributes(context.ServiceMethod).FirstOrDefault(x => x.GetType() == typeof(EasyCachingAbleAttribute)) is EasyCachingAbleAttribute attribute)
+            if (GetMethodAttributes(context.ServiceMethod).FirstOrDefault(x => typeof(EasyCachingAbleAttribute).IsAssignableFrom(x.GetType())) is EasyCachingAbleAttribute attribute)
             {
                 var returnType = context.IsAsync()
                         ? context.ServiceMethod.ReturnType.GetGenericArguments().First()
                         : context.ServiceMethod.ReturnType;
-                        
+
                 var cacheKey = KeyGenerator.GetCacheKey(context.ServiceMethod, context.Parameters, attribute.CacheKeyPrefix);
 
                 object cacheValue = null;
                 var isAvailable = true;
                 try
                 {
-                    if(attribute.IsHybridProvider)
+                    if (attribute.IsHybridProvider)
                     {
                         cacheValue = await HybridCachingProvider.GetAsync(cacheKey, returnType);
                     }
@@ -195,7 +195,7 @@
         /// <param name="context">Context.</param>
         private async Task ProcessPutAsync(AspectContext context)
         {
-            if (GetMethodAttributes(context.ServiceMethod).FirstOrDefault(x => x.GetType() == typeof(EasyCachingPutAttribute)) is EasyCachingPutAttribute attribute && context.ReturnValue != null)
+            if (GetMethodAttributes(context.ServiceMethod).FirstOrDefault(x => typeof(EasyCachingPutAttribute).IsAssignableFrom(x.GetType())) is EasyCachingPutAttribute attribute && context.ReturnValue != null)
             {
                 var cacheKey = KeyGenerator.GetCacheKey(context.ServiceMethod, context.Parameters, attribute.CacheKeyPrefix);
 
@@ -232,7 +232,7 @@
         /// <param name="isBefore">If set to <c>true</c> is before.</param>
         private async Task ProcessEvictAsync(AspectContext context, bool isBefore)
         {
-            if (GetMethodAttributes(context.ServiceMethod).FirstOrDefault(x => x.GetType() == typeof(EasyCachingEvictAttribute)) is EasyCachingEvictAttribute attribute && attribute.IsBefore == isBefore)
+            if (GetMethodAttributes(context.ServiceMethod).FirstOrDefault(x => typeof(EasyCachingEvictAttribute).IsAssignableFrom(x.GetType())) is EasyCachingEvictAttribute attribute && attribute.IsBefore == isBefore)
             {
                 try
                 {

--- a/src/EasyCaching.Interceptor.Castle/EasyCachingInterceptor.cs
+++ b/src/EasyCaching.Interceptor.Castle/EasyCachingInterceptor.cs
@@ -107,7 +107,7 @@
         {
             var serviceMethod = invocation.Method ?? invocation.MethodInvocationTarget;
 
-            if (GetMethodAttributes(serviceMethod).FirstOrDefault(x => x.GetType() == typeof(EasyCachingAbleAttribute)) is EasyCachingAbleAttribute attribute)
+            if (GetMethodAttributes(serviceMethod).FirstOrDefault(x => typeof(EasyCachingAbleAttribute).IsAssignableFrom(x.GetType())) is EasyCachingAbleAttribute attribute)
             {
                 var returnType = serviceMethod.IsReturnTask()
                         ? serviceMethod.ReturnType.GetGenericArguments().First()
@@ -199,7 +199,7 @@
         {
             var serviceMethod = invocation.Method ?? invocation.MethodInvocationTarget;
 
-            if (GetMethodAttributes(serviceMethod).FirstOrDefault(x => x.GetType() == typeof(EasyCachingPutAttribute)) is EasyCachingPutAttribute attribute && invocation.ReturnValue != null)
+            if (GetMethodAttributes(serviceMethod).FirstOrDefault(x => typeof(EasyCachingPutAttribute).IsAssignableFrom(x.GetType())) is EasyCachingPutAttribute attribute && invocation.ReturnValue != null)
             {
                 var cacheKey = _keyGenerator.GetCacheKey(serviceMethod, invocation.Arguments, attribute.CacheKeyPrefix);
 
@@ -236,7 +236,7 @@
         {
             var serviceMethod = invocation.Method ?? invocation.MethodInvocationTarget;
 
-            if (GetMethodAttributes(serviceMethod).FirstOrDefault(x => x.GetType() == typeof(EasyCachingEvictAttribute)) is EasyCachingEvictAttribute attribute && attribute.IsBefore == isBefore)
+            if (GetMethodAttributes(serviceMethod).FirstOrDefault(x => typeof(EasyCachingEvictAttribute).IsAssignableFrom(x.GetType())) is EasyCachingEvictAttribute attribute && attribute.IsBefore == isBefore)
             {
                 try
                 {

--- a/test/EasyCaching.UnitTests/CustomeInterceptors/CustomCachingAbleAttribute.cs
+++ b/test/EasyCaching.UnitTests/CustomeInterceptors/CustomCachingAbleAttribute.cs
@@ -1,8 +1,8 @@
-﻿using EasyCaching.Core.Interceptor;
-using System;
-
-namespace EasyCaching.UnitTests.CustomInterceptors
+﻿namespace EasyCaching.UnitTests.CustomInterceptors
 {
+    using EasyCaching.Core.Interceptor;
+    using System;
+
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
     class CustomCachingAbleAttribute: EasyCachingAbleAttribute
     {

--- a/test/EasyCaching.UnitTests/CustomeInterceptors/CustomCachingAbleAttribute.cs
+++ b/test/EasyCaching.UnitTests/CustomeInterceptors/CustomCachingAbleAttribute.cs
@@ -1,0 +1,15 @@
+﻿using EasyCaching.Core.Interceptor;
+using System;
+
+namespace EasyCaching.UnitTests.CustomInterceptors
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = true)]
+    class CustomCachingAbleAttribute: EasyCachingAbleAttribute
+    {
+        public CustomCachingAbleAttribute()
+        {
+            Expiration = 1;
+            CacheKeyPrefix = "Custom";
+        }
+    }
+}

--- a/test/EasyCaching.UnitTests/CustomeInterceptors/CustomCachingEvictAttribute.cs
+++ b/test/EasyCaching.UnitTests/CustomeInterceptors/CustomCachingEvictAttribute.cs
@@ -1,0 +1,14 @@
+﻿using EasyCaching.Core.Interceptor;
+using System;
+
+namespace EasyCaching.UnitTests.CustomInterceptors
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = true)]
+    class CustomCachingEvictAttribute : EasyCachingEvictAttribute
+    {
+        public CustomCachingEvictAttribute()
+        {
+            CacheKeyPrefix = "Custom";
+        }
+    }
+}

--- a/test/EasyCaching.UnitTests/CustomeInterceptors/CustomCachingEvictAttribute.cs
+++ b/test/EasyCaching.UnitTests/CustomeInterceptors/CustomCachingEvictAttribute.cs
@@ -1,8 +1,8 @@
-﻿using EasyCaching.Core.Interceptor;
-using System;
-
-namespace EasyCaching.UnitTests.CustomInterceptors
+﻿namespace EasyCaching.UnitTests.CustomInterceptors
 {
+    using EasyCaching.Core.Interceptor;
+    using System;
+
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
     class CustomCachingEvictAttribute : EasyCachingEvictAttribute
     {

--- a/test/EasyCaching.UnitTests/CustomeInterceptors/CustomCachingPutAttribute.cs
+++ b/test/EasyCaching.UnitTests/CustomeInterceptors/CustomCachingPutAttribute.cs
@@ -1,0 +1,15 @@
+﻿using EasyCaching.Core.Interceptor;
+using System;
+
+namespace EasyCaching.UnitTests.CustomInterceptors
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = true)]
+    class CustomCachingPutAttribute : EasyCachingPutAttribute
+    {
+        public CustomCachingPutAttribute()
+        {
+            Expiration = 1;
+            CacheKeyPrefix = "Custom";
+        }
+    }
+}

--- a/test/EasyCaching.UnitTests/CustomeInterceptors/CustomCachingPutAttribute.cs
+++ b/test/EasyCaching.UnitTests/CustomeInterceptors/CustomCachingPutAttribute.cs
@@ -1,8 +1,8 @@
-﻿using EasyCaching.Core.Interceptor;
-using System;
-
-namespace EasyCaching.UnitTests.CustomInterceptors
+﻿namespace EasyCaching.UnitTests.CustomInterceptors
 {
+    using EasyCaching.Core.Interceptor;
+    using System;
+
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
     class CustomCachingPutAttribute : EasyCachingPutAttribute
     {

--- a/test/EasyCaching.UnitTests/Infrastructure/IExampleService.cs
+++ b/test/EasyCaching.UnitTests/Infrastructure/IExampleService.cs
@@ -1,6 +1,7 @@
 ﻿namespace EasyCaching.UnitTests.Infrastructure
 {
     using EasyCaching.Core.Interceptor;
+    using EasyCaching.UnitTests.CustomInterceptors;
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
@@ -35,6 +36,15 @@
 
         [EasyCachingAble(Expiration = 1)]
         Task<string> AbleTestWithNullValueAsync();
+
+        [CustomCachingAble]
+        string CustomAbleAttributeTest();
+
+        [CustomCachingPut]
+        string CustomPutAttributeTest(int num);
+
+        [CustomCachingEvict]
+        string CustomEvictAttributeTest();
     }
 
     public class CastleExampleService : ICastleExampleService//, IEasyCaching
@@ -48,7 +58,6 @@
         {
             return "EvictTest";
         }
-
 
         public string GetCurrentUTC()
         {
@@ -87,6 +96,21 @@
         public Task<string> AbleTestWithNullValueAsync()
         {
             return Task.FromResult<string>(null);
+        }
+
+        public string CustomAbleAttributeTest()
+        {
+            return GetCurrentUTC();
+        }
+
+        public string CustomPutAttributeTest(int num)
+        {
+            return $"CustomPutTest-{num}";
+        }
+
+        public string CustomEvictAttributeTest()
+        {
+            return "CustomEvictTest";
         }
     }
 
@@ -129,6 +153,15 @@
 
         [EasyCachingAble(Expiration = 1)]
         Task<string> AbleTestWithNullValueAsync();
+
+        [CustomCachingAble]
+        string CustomAbleAttributeTest();
+
+        [CustomCachingPut]
+        string CustomPutAttributeTest(int num);
+
+        [CustomCachingEvict]
+        string CustomEvictAttributeTest();
     }
 
     public class AspectCoreExampleService : IAspectCoreExampleService
@@ -198,6 +231,21 @@
         public Task<string> AbleTestWithNullValueAsync()
         {
             return Task.FromResult<string>(null);
+        }
+
+        public string CustomAbleAttributeTest()
+        {
+            return GetCurrentUTC();
+        }
+
+        public string CustomPutAttributeTest(int num)
+        {
+            return $"CustomPutTest-{num}";
+        }
+
+        public string CustomEvictAttributeTest()
+        {
+            return "CustomEvictTest";
         }
     }
 }

--- a/test/EasyCaching.UnitTests/InterceptorTests/AspectCoreInterceptorTest.cs
+++ b/test/EasyCaching.UnitTests/InterceptorTests/AspectCoreInterceptorTest.cs
@@ -198,6 +198,62 @@
             Assert.Null(tick1);
             Assert.Equal(tick1, tick2);
         }
+
+        [Fact]
+        protected virtual void Interceptor_Should_Recognize_Subclass_Of_EasyCachingAble_Attribute()
+        {
+            var tick1 = _service.CustomAbleAttributeTest();
+
+            Thread.Sleep(1);
+
+            var tick2 = _service.CustomAbleAttributeTest();
+
+            Assert.Equal(tick1, tick2);
+
+            Thread.Sleep(1100);
+
+            var tick3 = _service.CustomAbleAttributeTest();
+
+            Assert.NotEqual(tick3, tick1);
+        }
+
+        [Fact]
+        protected virtual void Interceptor_Should_Recognize_Subclass_Of_EasyCachingPut_Attribute()
+        {
+            var str = _service.CustomPutAttributeTest(1);
+
+            var method = typeof(AspectCoreExampleService).GetMethod("CustomPutAttributeTest");
+
+            var key = _keyGenerator.GetCacheKey(method, new object[] { 1 }, "Custom");
+
+            var value = _cachingProvider.Get<string>(key);
+
+            Assert.True(value.HasValue);
+            Assert.Equal("CustomPutTest-1", value.Value);
+        }
+
+        [Fact]
+        protected virtual void Interceptor_Should_Recognize_Subclass_Of_EasyCachingEvict_Attribute()
+        {
+            var method = typeof(AspectCoreExampleService).GetMethod("CustomEvictAttributeTest");
+
+            var key = _keyGenerator.GetCacheKey(method, null, "Custom");
+
+            var cachedValue = Guid.NewGuid().ToString();
+
+            _cachingProvider.Set(key, cachedValue, TimeSpan.FromSeconds(30));
+
+            var value = _cachingProvider.Get<string>(key);
+
+            Assert.True(value.HasValue);
+            Assert.Equal(cachedValue, value.Value);
+
+            _service.CustomEvictAttributeTest();
+
+            var after = _cachingProvider.Get<string>(key);
+
+            Assert.False(after.HasValue);
+        }
     }
 
     public class AspectCoreInterceptorTest : BaseAspectCoreInterceptorTest

--- a/test/EasyCaching.UnitTests/InterceptorTests/CastleInterceptorTest.cs
+++ b/test/EasyCaching.UnitTests/InterceptorTests/CastleInterceptorTest.cs
@@ -203,6 +203,62 @@
             Assert.Null(tick1);
             Assert.Equal(tick1, tick2);
         }
+
+        [Fact]
+        protected virtual void Interceptor_Should_Recognize_Subclass_Of_EasyCachingAble_Attribute()
+        {
+            var tick1 = _service.CustomAbleAttributeTest();
+
+            Thread.Sleep(1);
+
+            var tick2 = _service.CustomAbleAttributeTest();
+
+            Assert.Equal(tick1, tick2);
+
+            Thread.Sleep(1100);
+
+            var tick3 = _service.CustomAbleAttributeTest();
+
+            Assert.NotEqual(tick3, tick1);
+        }
+
+        [Fact]
+        protected virtual void Interceptor_Should_Recognize_Subclass_Of_EasyCachingPut_Attribute()
+        {
+            var str = _service.CustomPutAttributeTest(1);
+
+            var method = typeof(AspectCoreExampleService).GetMethod("CustomPutAttributeTest");
+
+            var key = _keyGenerator.GetCacheKey(method, new object[] { 1 }, "Custom");
+
+            var value = _cachingProvider.Get<string>(key);
+
+            Assert.True(value.HasValue);
+            Assert.Equal("CustomPutTest-1", value.Value);
+        }
+
+        [Fact]
+        protected virtual void Interceptor_Should_Recognize_Subclass_Of_EasyCachingEvict_Attribute()
+        {
+            var method = typeof(AspectCoreExampleService).GetMethod("CustomEvictAttributeTest");
+
+            var key = _keyGenerator.GetCacheKey(method, null, "Custom");
+
+            var cachedValue = Guid.NewGuid().ToString();
+
+            _cachingProvider.Set(key, cachedValue, TimeSpan.FromSeconds(30));
+
+            var value = _cachingProvider.Get<string>(key);
+
+            Assert.True(value.HasValue);
+            Assert.Equal(cachedValue, value.Value);
+
+            _service.CustomEvictAttributeTest();
+
+            var after = _cachingProvider.Get<string>(key);
+
+            Assert.False(after.HasValue);
+        }
     }
 
     public class CastleInterceptorTest : BaseCastleInterceptorTest


### PR DESCRIPTION
I think maybe this can get better extensibility.

e.g.
```cs
[Cached]
//[EasyCachingAble(Expiration = 300, IsHybridProvider = true)]
Task<IEnumerable<CategoryResponse>> GetByLevelAsync(ApiContext apiContext, int level, int limit, int childrenLimit, string structure);
```

```cs
[AttributeUsage(AttributeTargets.Method, Inherited = true)]
public class CachedAttribute : EasyCachingAbleAttribute
{
    /// <summary>
    /// Gets or sets a value indicating whether is hybrid provider
    /// </summary>
    public new bool IsHybridProvider { get; set; } = true;

    public CachedAttribute()
    {
        Expiration = AppSettingsConfig.Configuration.GetSection("Cache:Expiration").Get<int>();
    }
}
```

