### PR TITLE
Flubu build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   # - if test "$TRAVIS_OS_NAME" == "linux"; then docker run -p 6388:6379 --name redis6388 -d redis:latest redis-server; fi  
   # - if test "$TRAVIS_OS_NAME" == "linux"; then docker run -p 11211:11211 --name memcached1 -d memcached:latest memcached -m 64 -c 2048; fi  
   # - if test "$TRAVIS_OS_NAME" == "linux"; then docker run -p 11212:11211 --name memcached2 -d memcached:latest memcached -m 64 -c 2048; fi  
-  - if test "$TRAVIS_OS_NAME" == "linux"; then dotnet restore; fi
-  - if test "$TRAVIS_OS_NAME" == "osx"; then dotnet restore --disable-parallel; fi  
-  - dotnet build -c Release
+  - export PATH="$PATH:$HOME/.dotnet/tools"
+  - dotnet tool install --global FlubuCore.GlobalTool --version 4.2.8
+  - flubu build -s=build/BuildScript.cs
   # - if test "$TRAVIS_OS_NAME" == "linux"; then dotnet test -c Release --no-build ./test/EasyCaching.UnitTests/EasyCaching.UnitTests.csproj; fi

--- a/Build.csproj
+++ b/Build.csproj
@@ -1,0 +1,59 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="article\**" />
+    <Compile Remove="Build\bin\**" />
+    <Compile Remove="Build\obj\**" />
+    <Compile Remove="docs\**" />
+    <Compile Remove="Image\**" />
+    <Compile Remove="lang\**" />
+    <Compile Remove="media\**" />
+    <Compile Remove="samples\**" />
+    <Compile Remove="sample\**" />
+    <Compile Remove="src\**" />
+    <Compile Remove="test\**" />
+    <EmbeddedResource Remove="article\**" />
+    <EmbeddedResource Remove="Build\bin\**" />
+    <EmbeddedResource Remove="Build\obj\**" />
+    <EmbeddedResource Remove="docs\**" />
+    <EmbeddedResource Remove="Image\**" />
+    <EmbeddedResource Remove="lang\**" />
+    <EmbeddedResource Remove="media\**" />
+    <EmbeddedResource Remove="samples\**" />
+    <EmbeddedResource Remove="sample\**" />
+    <EmbeddedResource Remove="src\**" />
+    <EmbeddedResource Remove="test\**" />
+    <None Remove="article\**" />
+    <None Remove="Build\bin\**" />
+    <None Remove="Build\obj\**" />
+    <None Remove="docs\**" />
+    <None Remove="Image\**" />
+    <None Remove="lang\**" />
+    <None Remove="media\**" />
+    <None Remove="samples\**" />
+    <None Remove="sample\**" />
+    <None Remove="src\**" />
+    <None Remove="test\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove=".gitattributes" />
+    <None Remove=".gitignore" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FlubuCore" Version="4.2.8" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <DotNetCliToolReference Include="dotnet-flubu" Version="4.2.8" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Folder Include="output\" />
+  </ItemGroup>
+</Project>

--- a/EasyCaching.sln
+++ b/EasyCaching.sln
@@ -52,7 +52,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyCaching.Bus.CSRedis", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyCaching.Disk", "src\EasyCaching.Disk\EasyCaching.Disk.csproj", "{3D48FD75-01D6-44F9-B7C3-CB6DE784F476}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyCaching.Demo.ConsoleApp", "sample\EasyCaching.Demo.ConsoleApp\EasyCaching.Demo.ConsoleApp.csproj", "{359AE3CD-B8EE-49B1-95A1-685FD4D5EBE8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyCaching.Demo.ConsoleApp", "sample\EasyCaching.Demo.ConsoleApp\EasyCaching.Demo.ConsoleApp.csproj", "{359AE3CD-B8EE-49B1-95A1-685FD4D5EBE8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Build", "Build.csproj", "{43AD80E9-696B-4042-9D50-B26F48BE1928}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -152,6 +154,10 @@ Global
 		{359AE3CD-B8EE-49B1-95A1-685FD4D5EBE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{359AE3CD-B8EE-49B1-95A1-685FD4D5EBE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{359AE3CD-B8EE-49B1-95A1-685FD4D5EBE8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43AD80E9-696B-4042-9D50-B26F48BE1928}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43AD80E9-696B-4042-9D50-B26F48BE1928}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43AD80E9-696B-4042-9D50-B26F48BE1928}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43AD80E9-696B-4042-9D50-B26F48BE1928}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -180,6 +186,7 @@ Global
 		{861E5373-BEF6-4AA2-92C7-8F4941A079E7} = {A0F5CC7E-155F-4726-8DEB-E966950B3FE9}
 		{3D48FD75-01D6-44F9-B7C3-CB6DE784F476} = {A0F5CC7E-155F-4726-8DEB-E966950B3FE9}
 		{359AE3CD-B8EE-49B1-95A1-685FD4D5EBE8} = {F88D727A-9F9C-43D9-90B1-D4A02BF8BC98}
+		{43AD80E9-696B-4042-9D50-B26F48BE1928} = {A0F5CC7E-155F-4726-8DEB-E966950B3FE9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {63A57886-054B-476C-AAE1-8D7C8917682E}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,15 +38,11 @@ for:
   - ps: docker run -p 11211:11211 --name memcached1 -d bitnami/memcached:latest
   - ps: docker run -p 11212:11211 --name memcached2 -d bitnami/memcached:latest
   - ps: docker ps -a
-  - ps: dotnet restore
+  - ps: dotnet tool install --global FlubuCore.GlobalTool --version 4.2.8
 
   build_script:
-  - ps: dotnet build -c Release
-
-  test_script:
-  - ps: docker ps -a
-  - ps: dotnet test -c Release --no-build .\test\EasyCaching.UnitTests\EasyCaching.UnitTests.csproj
-
+   - ps: flubu Rebuild.Server
+ 
 -
   matrix:
     only:
@@ -66,13 +62,8 @@ for:
   - sh: docker run -p 11211:11211 --name memcached1 -d memcached memcached -m 64 -c 2048
   - sh: docker run -p 11212:11211 --name memcached2 -d memcached memcached -m 64 -c 2048
   - sh: docker ps -a
-  - sh: dotnet restore
+  - sh: dotnet tool install --global FlubuCore.GlobalTool --version 4.2.8
   
   build_script:
-  - sh: dotnet build -c Release
-  
-  test_script:
-  - ps: docker ps -a
-  - sh: dotnet test -c Release --no-build ./test/EasyCaching.UnitTests/EasyCaching.UnitTests.csproj
-  
-   
+  - sh: flubu Rebuild -s=build/BuildScript.cs
+    

--- a/build/BuildScript.cs
+++ b/build/BuildScript.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.IO;
+using FlubuCore.Context;
+using FlubuCore.Context.FluentInterface.Interfaces;
+using FlubuCore.Scripting;
+
+namespace Build
+{
+    public class BuildScript : DefaultBuildScript
+    {
+        [FromArg("apiKey", "Nuget api key for publishing nuget package.")]
+        public string NugetApiKey { get; set; }
+
+        protected override void ConfigureBuildProperties(IBuildPropertiesContext context)
+        {
+            context.Properties.Set(BuildProps.ProductId, "EasyCaching");
+            context.Properties.Set(BuildProps.SolutionFileName, "EasyCaching.sln");
+            context.Properties.Set(BuildProps.OutputDir, "output");
+            context.Properties.Set(BuildProps.BuildConfiguration, "Release");
+        }
+
+        protected override void ConfigureTargets(ITaskContext context)
+        {
+            var build = context.CreateTarget("Build")
+                .SetDescription("Build's the solution.")
+                .AddCoreTask(x => x.Clean()
+                    .CleanOutputDir())
+                .AddCoreTask(x => x.Restore())
+                .AddCoreTask(x => x.Build());
+
+            var runTests = context.CreateTarget("Run.Tests")
+                .SetDescription("Run's all Easy caching tests.")
+                .AddTask(X => X.RunProgramTask("docker")
+                    .WithArguments("ps", "-a"))
+                .AddCoreTask(x => x.Test().Project("test/EasyCaching.UnitTests/EasyCaching.UnitTests.csproj").NoBuild());              
+
+           var nugetPublish = context.CreateTarget("Nuget.Publish")
+                .SetDescription("Packs and publishes nuget package.")
+                .ForEach(_easyCachingProjectsToPack, (project, target) =>
+                {
+                    target
+                        .AddCoreTask(x => x.Pack()
+                            .Project(project)
+                            .IncludeSymbols()
+                            .OutputDirectory("output"));
+                })
+                .Do(PublishNuGetPackage);
+
+           var rebuild = context.CreateTarget("Rebuild")
+                .SetAsDefault()
+                .DependsOn(build);
+
+            context.CreateTarget("Rebuild.Server")
+                .SetAsDefault()
+                .DependsOn(rebuild)
+                .DependsOn(nugetPublish);
+        }
+
+        private void PublishNuGetPackage(ITaskContext context)
+        {
+
+            var packageFiles = Directory.GetFiles(@"./output", "*.nupkg");
+
+            foreach (var packageFile in packageFiles)
+            {
+                if (packageFile.EndsWith("symbols.nupkg", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                context.CoreTasks().NugetPush(packageFile)
+                    .DoNotFailOnError((e) => { context.LogInfo($"Failed to publish Nuget package."); })
+                    .ServerUrl("https://www.nuget.org/api/v2/package")
+                    .ApiKey(NugetApiKey)
+                    .Execute(context);
+            }
+        }
+
+        private string[] _easyCachingProjectsToPack = new string[]
+        {
+            "src/EasyCaching.Core/EasyCaching.Core.csproj",
+            "src/EasyCaching.Bus.CSRedis/EasyCaching.Bus.CSRedis.csproj",
+            "src/EasyCaching.Bus.RabbitMQ/EasyCaching.Bus.RabbitMQ.csproj",
+            "src/EasyCaching.Bus.Redis/EasyCaching.Bus.Redis.csproj",
+            "src/EasyCaching.CSRedis/EasyCaching.CSRedis.csproj",
+            "src/EasyCaching.Disk/EasyCaching.Disk.csproj",
+            "src/EasyCaching.HybridCache/EasyCaching.HybridCache.csproj",
+            "src/EasyCaching.InMemory/EasyCaching.InMemory.csproj",
+            "src/EasyCaching.Interceptor.AspectCore/EasyCaching.Interceptor.AspectCore.csproj",
+            "src/EasyCaching.Interceptor.Castle/EasyCaching.Interceptor.Castle.csproj",
+            "src/EasyCaching.Memcached/EasyCaching.Memcached.csproj",
+            "src/EasyCaching.Redis/EasyCaching.Redis.csproj",
+            "src/EasyCaching.ResponseCaching/EasyCaching.ResponseCaching.csproj",
+            "src/EasyCaching.Serialization.Json/EasyCaching.Serialization.Json.csproj",
+            "src/EasyCaching.Serialization.MessagePack/EasyCaching.Serialization.MessagePack.csproj",
+            "src/EasyCaching.Serialization.Protobuf/EasyCaching.Serialization.Protobuf.csproj",
+            "src/EasyCaching.SQLite/EasyCaching.SQLite.csproj",
+        };
+    }
+}

--- a/build/BuildScript.cs
+++ b/build/BuildScript.cs
@@ -32,9 +32,10 @@ namespace Build
                 .SetDescription("Run's all Easy caching tests.")
                 .AddTask(X => X.RunProgramTask("docker")
                     .WithArguments("ps", "-a"))
-                .AddCoreTask(x => x.Test().Project("test/EasyCaching.UnitTests/EasyCaching.UnitTests.csproj").NoBuild());              
+                .AddCoreTask(x => x.Test().Project("test/EasyCaching.UnitTests/EasyCaching.UnitTests.csproj")
+                    .NoBuild());
 
-           var nugetPublish = context.CreateTarget("Nuget.Publish")
+            var nugetPublish = context.CreateTarget("Nuget.Publish")
                 .SetDescription("Packs and publishes nuget package.")
                 .ForEach(_easyCachingProjectsToPack, (project, target) =>
                 {
@@ -46,7 +47,7 @@ namespace Build
                 })
                 .Do(PublishNuGetPackage);
 
-           var rebuild = context.CreateTarget("Rebuild")
+            var rebuild = context.CreateTarget("Rebuild")
                 .SetAsDefault()
                 .DependsOn(build);
 
@@ -58,7 +59,6 @@ namespace Build
 
         private void PublishNuGetPackage(ITaskContext context)
         {
-
             var packageFiles = Directory.GetFiles(@"./output", "*.nupkg");
 
             foreach (var packageFile in packageFiles)

--- a/build/BuildScript.cs
+++ b/build/BuildScript.cs
@@ -43,14 +43,14 @@ namespace Build
                         .AddCoreTask(x => x.Pack()
                             .Project(project)
                             .IncludeSymbols()
-                            .OutputDirectory("output"));
+                            .OutputDirectory(context.Properties.GetOutputDir()));
                 })
                 .Do(PublishNuGetPackage);
 
             var rebuild = context.CreateTarget("Rebuild")
                 .SetAsDefault()
-                .DependsOn(build);
-
+                .DependsOn(build, runTests);
+            
             context.CreateTarget("Rebuild.Server")
                 .SetAsDefault()
                 .DependsOn(rebuild)
@@ -59,7 +59,7 @@ namespace Build
 
         private void PublishNuGetPackage(ITaskContext context)
         {
-            var packageFiles = Directory.GetFiles(@"./output", "*.nupkg");
+            var packageFiles = Directory.GetFiles(context.Properties.GetOutputDir(), "*.nupkg");
 
             foreach (var packageFile in packageFiles)
             {

--- a/build/BuildScript.cs
+++ b/build/BuildScript.cs
@@ -29,7 +29,7 @@ namespace Build
                 .AddCoreTask(x => x.Build());
 
             var runTests = context.CreateTarget("Run.Tests")
-                .SetDescription("Run's all Easy caching tests.")
+                .SetDescription("Run's all EasyCaching tests.")
                 .AddTask(X => X.RunProgramTask("docker")
                     .WithArguments("ps", "-a"))
                 .AddCoreTask(x => x.Test().Project("test/EasyCaching.UnitTests/EasyCaching.UnitTests.csproj")


### PR DESCRIPTION
Versioning: All projects currently gets version from EasyCaching.ProjectVersion.txt. If you want this can be changed back to version.props but it's a bit harder to make publishing of nuget packages through build script. It seems to me that this is the type of solution that all projects should have same version.

Nuget publishing: Nuget package will be published automatically when you increase version in EasyCaching.ProjectVersion.txt as I said this can be changed to your preferences. Before nuget publishing will work you have to add nuget api key as environment variable in travis (don't worry it won't be publicly visible.)
name of the environemt variable must be 'apiKey' you can add it in travis -> More Options -> Settings -> Environment variables

If u have any questions fell free to ask or if I wan't any changes in build script just tell.

P.S. In next days i'll create another pull request where I will put docker commands in build script.