### PR TITLE
EasyCaching.Serialization.Json提供JsonSerializerSettings的配置

### DIFF
--- a/sample/EasyCaching.Demo.ConsoleApp/Program.cs
+++ b/sample/EasyCaching.Demo.ConsoleApp/Program.cs
@@ -16,7 +16,14 @@
             {
                 option.UseInMemory("m1");
 
-                option.UseSQLite(c => 
+                //option.UseRedis(config =>
+                //{
+                //    config.DBConfig = new Redis.RedisDBOptions { Configuration = "localhost" };
+                //    config.SerializerName = "json";
+                //}, "r1");
+
+
+                option.UseSQLite(c =>
                 {
                     c.DBConfig = new SQLiteDBOptions
                     {
@@ -24,13 +31,32 @@
                         CacheMode = Microsoft.Data.Sqlite.SqliteCacheMode.Default,
                         OpenMode = Microsoft.Data.Sqlite.SqliteOpenMode.Memory,
                     };
-                }, "s1");               
+                }, "s1");
+
+                //option.WithJson(jsonSerializerSettingsConfigure: x =>
+                //{
+                //    x.TypeNameHandling = Newtonsoft.Json.TypeNameHandling.None;
+                //}, "json");
             });
 
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             var factory = serviceProvider.GetService<IEasyCachingProviderFactory>();
 
+            //var reidsCache = factory.GetCachingProvider("r1");
+
+            //reidsCache.Set<Product>("rkey", new Product() { Name = "test" }, TimeSpan.FromSeconds(20));
+
+            //var reidsVal = reidsCache.Get<Product>("rkey");
+
+            //Console.WriteLine($"redis cache get value, {reidsVal.HasValue} {reidsVal.IsNull} {reidsVal.Value} ");
+
+
             var mCache = factory.GetCachingProvider("m1");
+
+            mCache.Set<Product>("mkey1", new Product() { Name = "test" }, TimeSpan.FromSeconds(20));
+
+            var mVal1 = mCache.Get<Product>("mkey1");
+
 
             mCache.Set<string>("mkey", "mvalue", TimeSpan.FromSeconds(20));
 
@@ -48,5 +74,11 @@
 
             Console.ReadKey();
         }
+    }
+
+    public class Product
+    {
+
+        public string Name { get; set; }
     }
 }

--- a/src/EasyCaching.Serialization.Json/Configurations/EasyCachingOptionsExtensions.cs
+++ b/src/EasyCaching.Serialization.Json/Configurations/EasyCachingOptionsExtensions.cs
@@ -2,6 +2,7 @@
 {
     using EasyCaching.Core.Configurations;
     using EasyCaching.Serialization.Json;
+    using Newtonsoft.Json;
     using System;
 
     /// <summary>
@@ -14,7 +15,7 @@
         /// </summary>        
         /// <param name="options">Options.</param>        
         /// <param name="name">The name of this serializer instance.</param>        
-        public static EasyCachingOptions WithJson(this EasyCachingOptions options, string name = "json") => options.WithJson(x => { }, name);
+        public static EasyCachingOptions WithJson(this EasyCachingOptions options, string name = "json") => options.WithJson(configure: x => { }, name);
 
         /// <summary>
         /// Withs the json serializer.
@@ -24,7 +25,37 @@
         /// <param name="name">The name of this serializer instance.</param>     
         public static EasyCachingOptions WithJson(this EasyCachingOptions options, Action<EasyCachingJsonSerializerOptions> configure, string name)
         {
-            options.RegisterExtension(new JsonOptionsExtension(name, configure));
+            var easyCachingJsonSerializerOptions = new EasyCachingJsonSerializerOptions();
+
+            configure(easyCachingJsonSerializerOptions);
+
+            Action<JsonSerializerSettings> jsonSerializerSettings = x =>
+            {
+                x.ReferenceLoopHandling = easyCachingJsonSerializerOptions.ReferenceLoopHandling;
+                x.TypeNameHandling = easyCachingJsonSerializerOptions.TypeNameHandling;
+                x.MetadataPropertyHandling = easyCachingJsonSerializerOptions.MetadataPropertyHandling;
+                x.MissingMemberHandling = easyCachingJsonSerializerOptions.MissingMemberHandling;
+                x.NullValueHandling = easyCachingJsonSerializerOptions.NullValueHandling;
+                x.DefaultValueHandling = easyCachingJsonSerializerOptions.DefaultValueHandling;
+                x.ObjectCreationHandling = easyCachingJsonSerializerOptions.ObjectCreationHandling;
+                x.PreserveReferencesHandling = easyCachingJsonSerializerOptions.PreserveReferencesHandling;
+                x.ConstructorHandling = easyCachingJsonSerializerOptions.ConstructorHandling;
+            };
+
+            options.RegisterExtension(new JsonOptionsExtension(name, jsonSerializerSettings));
+
+            return options;
+        }
+
+        /// <summary>
+        /// Withs the json serializer.
+        /// </summary>        
+        /// <param name="options">Options.</param>
+        /// <param name="jsonSerializerSettingsConfigure">Configure serializer settings.</param>
+        /// <param name="name">The name of this serializer instance.</param>     
+        public static EasyCachingOptions WithJson(this EasyCachingOptions options, Action<JsonSerializerSettings> jsonSerializerSettingsConfigure, string name)
+        {
+            options.RegisterExtension(new JsonOptionsExtension(name, jsonSerializerSettingsConfigure));
 
             return options;
         }

--- a/src/EasyCaching.Serialization.Json/Configurations/JsonOptionsExtension.cs
+++ b/src/EasyCaching.Serialization.Json/Configurations/JsonOptionsExtension.cs
@@ -4,6 +4,7 @@
     using EasyCaching.Core.Configurations;
     using EasyCaching.Core.Serialization;
     using Microsoft.Extensions.DependencyInjection;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// Json options extension.
@@ -18,14 +19,14 @@
         /// <summary>
         /// The configure.
         /// </summary>
-        private readonly Action<EasyCachingJsonSerializerOptions> _configure;
+        private readonly Action<JsonSerializerSettings> _configure;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:EasyCaching.Serialization.Json.JsonOptionsExtension"/> class.
         /// </summary>
         /// <param name="name">Name.</param>
         /// <param name="configure">Configure.</param>
-        public JsonOptionsExtension(string name, Action<EasyCachingJsonSerializerOptions> configure)
+        public JsonOptionsExtension(string name, Action<JsonSerializerSettings> configure)
         {
             this._name = name;
             this._configure = configure;
@@ -37,7 +38,7 @@
         /// <param name="services">Services.</param>
         public void AddServices(IServiceCollection services)
         {
-            Action<EasyCachingJsonSerializerOptions> configure = x => { };
+            Action<JsonSerializerSettings> configure = x => { };
 
             if (_configure != null) configure = _configure;
 
@@ -45,7 +46,7 @@
             services.Configure(_name, configure);
             services.AddSingleton<IEasyCachingSerializer, DefaultJsonSerializer>(x=> 
             {
-                var optionsMon = x.GetRequiredService<Microsoft.Extensions.Options.IOptionsMonitor<EasyCachingJsonSerializerOptions>>();
+                var optionsMon = x.GetRequiredService<Microsoft.Extensions.Options.IOptionsMonitor<JsonSerializerSettings>>();
                 var options = optionsMon.Get(_name);
                 return new DefaultJsonSerializer(_name, options);
             });

--- a/src/EasyCaching.Serialization.Json/DefaultJsonSerializer.cs
+++ b/src/EasyCaching.Serialization.Json/DefaultJsonSerializer.cs
@@ -26,22 +26,11 @@
         /// Initializes a new instance of the <see cref="T:EasyCaching.Serialization.Json.DefaultJsonSerializer"/> class.
         /// </summary>
         /// <param name="name">Name.</param>
-        /// <param name="options">Options.</param>
-        public DefaultJsonSerializer(string name, EasyCachingJsonSerializerOptions options)
+        /// <param name="serializerSettings">serializerSettings.</param>
+        public DefaultJsonSerializer(string name, JsonSerializerSettings serializerSettings)
         {
             _name = name;
-            jsonSerializer = new JsonSerializer
-            { 
-                ReferenceLoopHandling = options.ReferenceLoopHandling,
-                TypeNameHandling = options.TypeNameHandling,
-                MetadataPropertyHandling = options.MetadataPropertyHandling,
-                MissingMemberHandling = options.MissingMemberHandling,
-                NullValueHandling = options.NullValueHandling,
-                DefaultValueHandling = options.DefaultValueHandling,
-                ObjectCreationHandling = options.ObjectCreationHandling,
-                PreserveReferencesHandling = options.PreserveReferencesHandling,
-                ConstructorHandling = options.ConstructorHandling
-            };
+            jsonSerializer = JsonSerializer.Create(serializerSettings); 
         }
 
         /// <summary>

--- a/test/EasyCaching.PerformanceTests/SerializerBenchmark.cs
+++ b/test/EasyCaching.PerformanceTests/SerializerBenchmark.cs
@@ -7,6 +7,7 @@
     using EasyCaching.Serialization.MessagePack;
     using EasyCaching.Serialization.Protobuf;
     using Microsoft.Extensions.Options;
+    using Newtonsoft.Json;
     using System;
     using System.Collections.Generic;
 
@@ -14,7 +15,7 @@
     [AllStatisticsColumn]
     public abstract class SerializerBenchmark
     {
-        private DefaultJsonSerializer _json = new DefaultJsonSerializer("json", new EasyCachingJsonSerializerOptions());
+        private DefaultJsonSerializer _json = new DefaultJsonSerializer("json", new JsonSerializerSettings());
         private DefaultMessagePackSerializer _messagepack = new DefaultMessagePackSerializer("msgpack");
         private DefaultProtobufSerializer _protobuf = new DefaultProtobufSerializer("proto");
         private DefaultBinaryFormatterSerializer _binary = new DefaultBinaryFormatterSerializer();

--- a/test/EasyCaching.UnitTests/SerializerTests/JsonSerializerTest.cs
+++ b/test/EasyCaching.UnitTests/SerializerTests/JsonSerializerTest.cs
@@ -10,7 +10,7 @@
     {
         public JsonSerializerTest()
         {
-            _serializer = new DefaultJsonSerializer("json", new EasyCachingJsonSerializerOptions());
+            _serializer = new DefaultJsonSerializer("json", new JsonSerializerSettings());
         }
 
         [Fact]
@@ -27,7 +27,7 @@
         [Fact]
         public void ReferenceLoopHandling_Test_Should_Succeed()
         {
-            var  serializer = new DefaultJsonSerializer("json", new EasyCachingJsonSerializerOptions()
+            var serializer = new DefaultJsonSerializer("json", new JsonSerializerSettings()
             {
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore
             });
@@ -54,12 +54,12 @@
         [Fact]
         public void NullValueHandling_Test_Should_Succeed()
         {
-            var  serializer = new DefaultJsonSerializer("json", new EasyCachingJsonSerializerOptions()
+            var serializer = new DefaultJsonSerializer("json", new JsonSerializerSettings()
             {
                 NullValueHandling = NullValueHandling.Ignore
             });
 
-            Employee joe = new Employee { Name = "Joe User" };           
+            Employee joe = new Employee { Name = "Joe User" };
 
             var joe_byte = serializer.Serialize(joe);
             var joe_obj = serializer.Deserialize<Employee>(joe_byte);


### PR DESCRIPTION
EasyCaching.Serialization.Json提供JsonSerializerSettings的配置，让使用方可以自定义配置json.net。
提供JsonSerializerSettings配置的原因：
EasyCachingJsonSerializerOptions中的属性只有部分JsonSerializerSettings的属性可以配置。
导致在使用中需要用到JsonSerializerSettings其他属性无法配置，比如：ContractResolver等
