### PR TITLE
Build - nuget api key

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,10 @@ image:
 configuration: Release
 clone_depth: 50
 
+environment:
+  api_key:
+    secure: EjcBgIRpoy3pxVyKUnQFNg==
+
 pull_requests:
   do_not_increment_build_number: true
 
@@ -41,7 +45,7 @@ for:
   - ps: dotnet tool install --global FlubuCore.GlobalTool --version 4.2.8
 
   build_script:
-   - ps: flubu Rebuild.Server
+   - ps: flubu Rebuild.Server -apiKey=$env:api_key
  
 -
   matrix:


### PR DESCRIPTION
I forgot to add it in previous pull request. 

Just replace in yaml with actual encrypted api key. You should encrypt it here https://ci.appveyor.com/tools/encrypt

environment:
  api_key:
    secure: **EjcBgIRpoy3pxVyKUnQFNg==**