### PR TITLE
Fix CompositeResolver usage

### DIFF
--- a/docs/MessagePack.md
+++ b/docs/MessagePack.md
@@ -54,12 +54,6 @@ Time issues can be solved using a combination of NativeDateTimeResolver+Contract
 ```cs
 public void ConfigureServices(IServiceCollection services)
 {
-    CompositeResolver.RegisterAndSetAsDefault(
-        // This can solve DateTime time zone problem
-        NativeDateTimeResolver.Instance,
-        ContractlessStandardResolver.Instance
-    );
-
     services.AddControllers();
 
     services.AddEasyCaching(option =>
@@ -77,6 +71,11 @@ public void ConfigureServices(IServiceCollection services)
         option.WithMessagePack( x => 
         {
             x.EnableCustomResolver = true; 
+            x.CustomResolvers = CompositeResolver.Create(
+                // This can solve DateTime time zone problem
+                NativeDateTimeResolver.Instance,
+                ContractlessStandardResolver.Instance
+            );
         },"mymsgpack");
     });
 }


### PR DESCRIPTION
Due to changes in version 2.x.x and later of MessagePack, the CompositeResolver.RegisterAndSetAsDefault() method has been removed and Create() method has been added instead.  
We need to get the output of the CompositeResolver.Create () method and pass it to x.CustomResolver.