### PR TITLE
Redis acl support

### DIFF
--- a/src/EasyCaching.Bus.Redis/Configurations/EasyCachingOptionsExtensions.cs
+++ b/src/EasyCaching.Bus.Redis/Configurations/EasyCachingOptionsExtensions.cs
@@ -51,6 +51,7 @@
                 x.ConnectionTimeout = redisOptions.ConnectionTimeout;
                 x.Database = redisOptions.Database;
                 x.IsSsl = redisOptions.IsSsl;
+                x.Username = redisOptions.Username;
                 x.Password = redisOptions.Password;
                 x.SslHost = redisOptions.SslHost;
 

--- a/src/EasyCaching.Bus.Redis/Configurations/RedisSubscriberProvider.cs
+++ b/src/EasyCaching.Bus.Redis/Configurations/RedisSubscriberProvider.cs
@@ -48,6 +48,7 @@
                 var configurationOptions = new ConfigurationOptions
                 {
                     ConnectTimeout = _options.ConnectionTimeout,
+                    User = _options.Username,
                     Password = _options.Password,
                     Ssl = _options.IsSsl,
                     SslHost = _options.SslHost,

--- a/src/EasyCaching.Bus.Redis/EasyCaching.Bus.Redis.csproj
+++ b/src/EasyCaching.Bus.Redis/EasyCaching.Bus.Redis.csproj
@@ -30,7 +30,7 @@
     <None Include="../../media/nuget-icon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.1.28" />
+    <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyCaching.Core\EasyCaching.Core.csproj" />

--- a/src/EasyCaching.Core/Configurations/BaseRedisOptions.cs
+++ b/src/EasyCaching.Core/Configurations/BaseRedisOptions.cs
@@ -8,6 +8,14 @@
     public class BaseRedisOptions
     {
         /// <summary>
+        /// Gets or sets the username to be used to connect to the Redis server.
+        /// </summary>
+        /// <value>
+        /// The username.
+        /// </value>
+        public string Username { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets the password to be used to connect to the Redis server.
         /// </summary>
         /// <value>

--- a/src/EasyCaching.Redis/Configurations/RedisDatabaseProvider.cs
+++ b/src/EasyCaching.Redis/Configurations/RedisDatabaseProvider.cs
@@ -65,6 +65,7 @@
                 var configurationOptions = new ConfigurationOptions
                 {
                     ConnectTimeout = _options.ConnectionTimeout,
+                    User = _options.Username,
                     Password = _options.Password,
                     Ssl = _options.IsSsl,
                     SslHost = _options.SslHost,

--- a/src/EasyCaching.Redis/EasyCaching.Redis.csproj
+++ b/src/EasyCaching.Redis/EasyCaching.Redis.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.1.28" />
+    <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyCaching.Core\EasyCaching.Core.csproj" />


### PR DESCRIPTION
The [latest Redis version (6.0)](https://redislabs.com/blog/diving-into-redis-6/) came out with the ACL (access control list) feature. ACLs bring the concept of “users” to Redis. Each user can have a defined set of capabilities that dictate which commands they can run and on what keys.

With this pull-request, I've added `Username` property to `Redis.DBConfigs` and pass it to the `ConfigurationOptions` of StackExchange.Redis and from now on, we can use this feature!