### PR TITLE
csredis引用版本升级到最新版, 替换必要的类型转换double->decimal

### DIFF
--- a/src/EasyCaching.CSRedis/DefaultCSRedisCachingProvider.Geo.cs
+++ b/src/EasyCaching.CSRedis/DefaultCSRedisCachingProvider.Geo.cs
@@ -13,11 +13,11 @@
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNullAndCountGTZero(values, nameof(values));
 
-            var list = new List<(double longitude, double latitude, object member)>();
+            var list = new List<(decimal longitude, decimal latitude, object member)>();
 
             foreach (var item in values)
             {
-                list.Add((item.longitude, item.latitude, item.member));
+                list.Add(((decimal longitude, decimal latitude, object member))(item.longitude, item.latitude, item.member));
             }
 
             var res = _cache.GeoAdd(cacheKey, list.ToArray());
@@ -29,11 +29,11 @@
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNullAndCountGTZero(values, nameof(values));
 
-            var list = new List<(double longitude, double latitude, object member)>();
+            var list = new List<(decimal longitude, decimal latitude, object member)>();
 
             foreach (var item in values)
             {
-                list.Add((item.longitude, item.latitude, item.member));
+                list.Add(((decimal longitude, decimal latitude, object member))(item.longitude, item.latitude, item.member));
             }
 
             var res = await _cache.GeoAddAsync(cacheKey, list.ToArray());
@@ -48,7 +48,7 @@
             ArgumentCheck.NotNullOrWhiteSpace(unit, nameof(unit));
 
             var res = _cache.GeoDist(cacheKey, member1, member2, GetGeoUnit(unit));
-            return res;
+            return (double?)res;
         }
 
         public async Task<double?> GeoDistAsync(string cacheKey, string member1, string member2, string unit = "m")
@@ -59,7 +59,7 @@
             ArgumentCheck.NotNullOrWhiteSpace(unit, nameof(unit));
 
             var res = await _cache.GeoDistAsync(cacheKey, member1, member2, GetGeoUnit(unit));
-            return res;
+            return (double?)res;
         }
 
         public List<string> GeoHash(string cacheKey, List<string> members)
@@ -92,7 +92,7 @@
             return res.ToList();
         }
 
-        public List<(double longitude, double latitude)?> GeoPos(string cacheKey, List<string> members)
+        public List<(decimal longitude, decimal latitude)?> GeoPos(string cacheKey, List<string> members)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNullAndCountGTZero(members, nameof(members));
@@ -107,7 +107,7 @@
             return res.ToList();
         }
 
-        public async Task<List<(double longitude, double latitude)?>> GeoPosAsync(string cacheKey, List<string> members)
+        public async Task<List<(decimal longitude, decimal latitude)?>> GeoPosAsync(string cacheKey, List<string> members)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNullAndCountGTZero(members, nameof(members));

--- a/src/EasyCaching.CSRedis/DefaultCSRedisCachingProvider.SortedSet.cs
+++ b/src/EasyCaching.CSRedis/DefaultCSRedisCachingProvider.SortedSet.cs
@@ -11,11 +11,11 @@
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
-            var param = new List<(double, object)>();
+            var param = new List<(decimal, object)>();
 
             foreach (var item in cacheValues)
             {
-                param.Add((item.Value, _serializer.Serialize(item.Key)));
+                param.Add(((decimal, object))(item.Value, _serializer.Serialize(item.Key)));
             }
 
             var len = _cache.ZAdd(cacheKey, param.ToArray());
@@ -35,7 +35,7 @@
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
-            var len = _cache.ZCount(cacheKey, min, max);
+            var len = _cache.ZCount(cacheKey, (decimal)min, (decimal)max);
             return len;
         }
         public double ZIncrBy(string cacheKey, string field, double val = 1)
@@ -43,8 +43,8 @@
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNullOrWhiteSpace(field, nameof(field));
 
-            var value = _cache.ZIncrBy(cacheKey, field, val);
-            return value;
+            var value = _cache.ZIncrBy(cacheKey, field, (decimal)val);
+            return (double)value;
         }
         public long ZLexCount(string cacheKey, string min, string max)
         {
@@ -106,18 +106,18 @@
 
             var score = _cache.ZScore(cacheKey, bytes);
 
-            return score;
+            return (double?)score;
         }
 
         public async Task<long> ZAddAsync<T>(string cacheKey, Dictionary<T, double> cacheValues)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
-            var param = new List<(double, object)>();
+            var param = new List<(decimal, object)>();
 
             foreach (var item in cacheValues)
             {
-                param.Add((item.Value, _serializer.Serialize(item.Key)));
+                param.Add(((decimal, object))(item.Value, _serializer.Serialize(item.Key)));
             }
 
             var len = await _cache.ZAddAsync(cacheKey, param.ToArray());
@@ -138,7 +138,7 @@
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
-            var len = await _cache.ZCountAsync(cacheKey, min, max);
+            var len = await _cache.ZCountAsync(cacheKey, (decimal)min, (decimal)max);
             return len;
         }
 
@@ -147,8 +147,8 @@
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNullOrWhiteSpace(field, nameof(field));
 
-            var value= await _cache.ZIncrByAsync(cacheKey, field, val);
-            return value;
+            var value= await _cache.ZIncrByAsync(cacheKey, field, (decimal)val);
+            return (double)value;
         }
 
         public async Task<long> ZLexCountAsync(string cacheKey, string min, string max)
@@ -210,7 +210,7 @@
 
             var score = await _cache.ZScoreAsync(cacheKey, bytes);
 
-            return score;
+            return (double?)score;
         }
 
     }

--- a/src/EasyCaching.CSRedis/DefaultCSRedisCachingProvider.String.cs
+++ b/src/EasyCaching.CSRedis/DefaultCSRedisCachingProvider.String.cs
@@ -26,16 +26,16 @@
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
-            var res = _cache.IncrByFloat(cacheKey, value);
-            return res;
+            var res = _cache.IncrByFloat(cacheKey, (decimal)value);
+            return (double)res;
         }
 
         public async Task<double> IncrByFloatAsync(string cacheKey, double value = 1)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
-            var res = await _cache.IncrByFloatAsync(cacheKey, value);
-            return res;
+            var res = await _cache.IncrByFloatAsync(cacheKey, (decimal)value);
+            return (double)res;
         }
 
         public bool StringSet(string cacheKey, string cacheValue, System.TimeSpan? expiration, string when)

--- a/src/EasyCaching.CSRedis/EasyCaching.CSRedis.csproj
+++ b/src/EasyCaching.CSRedis/EasyCaching.CSRedis.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CSRedisCore" Version="3.2.0" />
+    <PackageReference Include="CSRedisCore" Version="3.6.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyCaching.Core\EasyCaching.Core.csproj" />

--- a/src/EasyCaching.Core/IRedisCachingProvider.cs
+++ b/src/EasyCaching.Core/IRedisCachingProvider.cs
@@ -916,14 +916,14 @@
         /// <param name="cacheKey"></param>
         /// <param name="members"></param>
         /// <returns></returns>
-        List<(double longitude, double latitude)?> GeoPos(string cacheKey, List<string> members);
+        List<(decimal longitude, decimal latitude)?> GeoPos(string cacheKey, List<string> members);
         /// <summary>
         /// https://redis.io/commands/geopos
         /// </summary>
         /// <param name="cacheKey"></param>
         /// <param name="members"></param>
         /// <returns></returns>
-        Task<List<(double longitude, double latitude)?>> GeoPosAsync(string cacheKey, List<string> members);
+        Task<List<(decimal longitude, decimal latitude)?>> GeoPosAsync(string cacheKey, List<string> members);
         #endregion
 
         object Eval(string script, string cacheKey, List<object> args);

--- a/src/EasyCaching.Redis/DefaultRedisCachingProvider.Geo.cs
+++ b/src/EasyCaching.Redis/DefaultRedisCachingProvider.Geo.cs
@@ -95,7 +95,7 @@
             return res.ToList();
         }
 
-        public List<(double longitude, double latitude)?> GeoPos(string cacheKey, List<string> members)
+        public List<(decimal longitude, decimal latitude)?> GeoPos(string cacheKey, List<string> members)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNullAndCountGTZero(members, nameof(members));
@@ -108,13 +108,13 @@
 
             var res = _cache.GeoPosition(cacheKey, list.ToArray());
 
-            var tuple = new List<(double longitude, double latitude)?>();
+            var tuple = new List<(decimal longitude, decimal latitude)?>();
 
             foreach (var item in res)
             {
                 if (item.HasValue)
                 {
-                    tuple.Add((item.Value.Longitude, item.Value.Latitude));
+                    tuple.Add(((decimal longitude, decimal latitude)?)(item.Value.Longitude, item.Value.Latitude));
                 }
                 else
                 {
@@ -126,7 +126,7 @@
             return tuple;
         }
 
-        public async Task<List<(double longitude, double latitude)?>> GeoPosAsync(string cacheKey, List<string> members)
+        public async Task<List<(decimal longitude, decimal latitude)?>> GeoPosAsync(string cacheKey, List<string> members)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNullAndCountGTZero(members, nameof(members));
@@ -139,13 +139,13 @@
 
             var res = await _cache.GeoPositionAsync(cacheKey, list.ToArray());
 
-            var tuple = new List<(double longitude, double latitude)?>();
+            var tuple = new List<(decimal longitude, decimal latitude)?>();
 
             foreach (var item in res)
             {
                 if (item.HasValue)
                 {
-                    tuple.Add((item.Value.Longitude, item.Value.Latitude));
+                    tuple.Add(((decimal longitude, decimal latitude)?)(item.Value.Longitude, item.Value.Latitude));
                 }
                 else
                 {

--- a/test/EasyCaching.UnitTests/CachingTests/BaseRedisFeatureCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/BaseRedisFeatureCachingProviderTest.cs
@@ -1783,8 +1783,8 @@
             var pos = _provider.GeoPos(cacheKey, new List<string> { "Palermo", "Catania", "NonExisting" });
 
             Assert.Equal(3, pos.Count);
-            Assert.Contains(13.361389338970184, pos.Where(x => x.HasValue).Select(x => x.Value.longitude));
-            Assert.Contains(15.087267458438873, pos.Where(x => x.HasValue).Select(x => x.Value.longitude));
+            Assert.Contains(13.361389338970184m, pos.Where(x => x.HasValue).Select(x => x.Value.longitude));
+            Assert.Contains(15.087267458438873m, pos.Where(x => x.HasValue).Select(x => x.Value.longitude));
             Assert.Contains(null, pos);
 
             _provider.KeyDel(cacheKey);
@@ -1802,8 +1802,8 @@
             var pos = await _provider.GeoPosAsync(cacheKey, new List<string> { "Palermo", "Catania", "NonExisting" });
 
             Assert.Equal(3, pos.Count);
-            Assert.Contains(13.361389338970184, pos.Where(x => x.HasValue).Select(x => x.Value.longitude));
-            Assert.Contains(15.087267458438873, pos.Where(x => x.HasValue).Select(x => x.Value.longitude));
+            Assert.Contains(13.361389338970184m, pos.Where(x => x.HasValue).Select(x => x.Value.longitude));
+            Assert.Contains(15.087267458438873m, pos.Where(x => x.HasValue).Select(x => x.Value.longitude));
             Assert.Contains(null, pos);
 
             await _provider.KeyDelAsync(cacheKey);


### PR DESCRIPTION
因为csredis在[v3.3.0版本](https://github.com/2881099/csredis/issues/226#issuecomment-568838238)中把double转为decimal, 所以升级csredis引用, 就会涉及到类型修改, 为了兼容, 只修改了必要的接口类型, 其他都在csredis实现中做类型转换.

建议所有类型都做修改, 但是会涉及到`StackExchange.Redis`的实现方法, 请慎重考虑