### PR TITLE
feat: allow user to define client provided name

### DIFF
--- a/bus/EasyCaching.Bus.RabbitMQ/DefaultRabbitMQBus.cs
+++ b/bus/EasyCaching.Bus.RabbitMQ/DefaultRabbitMQBus.cs
@@ -64,7 +64,8 @@
                 VirtualHost = _options.VirtualHost,
                 RequestedConnectionTimeout = System.TimeSpan.FromMilliseconds(_options.RequestedConnectionTimeout),
                 SocketReadTimeout = System.TimeSpan.FromMilliseconds(_options.SocketReadTimeout),
-                SocketWriteTimeout = System.TimeSpan.FromMilliseconds(_options.SocketWriteTimeout)
+                SocketWriteTimeout = System.TimeSpan.FromMilliseconds(_options.SocketWriteTimeout),
+                ClientProvidedName = _options.ClientProvidedName
             };
 
             _subConnection = factory.CreateConnection();

--- a/src/EasyCaching.Core/Configurations/BaseRabbitMQOptions.cs
+++ b/src/EasyCaching.Core/Configurations/BaseRabbitMQOptions.cs
@@ -51,5 +51,10 @@
         /// Gets or sets queue message automatic deletion time (in milliseconds). Default 864000000 ms (10 days).
         /// </summary>
         public int QueueMessageExpires { get; set; } = 864000000;
+
+        /// <summary>
+        /// Gets or sets the client-provided name for the rabbit connection. Default null (handled by rabbit client)
+        /// </summary>
+        public string ClientProvidedName { get; set; }
     }
 }


### PR DESCRIPTION
In some cases, it is useful to provide a way for the application to give a meaningful name to the rabbit connection in order to be able to reason about existing connections on a rabbit server when there are multiple connections.