### PR TITLE
change register for DefaultEasyCachingProviderFactory

### DIFF
--- a/src/EasyCaching.CSRedis/Configurations/RedisOptionsExtension.cs
+++ b/src/EasyCaching.CSRedis/Configurations/RedisOptionsExtension.cs
@@ -52,7 +52,7 @@ using EasyCaching.CSRedis.DistributedLock;
 
             services.Configure(_name, _configure);
 
-            services.TryAddSingleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>());
 
             services.AddSingleton<EasyCachingCSRedisClient>(x =>
             {

--- a/src/EasyCaching.Disk/Configurations/DiskOptionsExtension.cs
+++ b/src/EasyCaching.Disk/Configurations/DiskOptionsExtension.cs
@@ -30,7 +30,7 @@
             services.AddOptions();
             services.Configure(_name, configure);
 
-            services.TryAddSingleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>());
             services.AddSingleton<IEasyCachingProvider, DefaultDiskCachingProvider>(x =>
             {
                 var optionsMon = x.GetRequiredService<Microsoft.Extensions.Options.IOptionsMonitor<DiskOptions>>();

--- a/src/EasyCaching.InMemory/Configurations/InMemoryOptionsExtension.cs
+++ b/src/EasyCaching.InMemory/Configurations/InMemoryOptionsExtension.cs
@@ -48,7 +48,7 @@
                 return new InMemoryCaching(_name, options.DBConfig);
             });
 
-            services.TryAddSingleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>());
             services.AddSingleton<IEasyCachingProvider, DefaultInMemoryCachingProvider>(x =>
             {
                 var mCache = x.GetServices<IInMemoryCaching>();

--- a/src/EasyCaching.LiteDB/Configurations/LiteDBOptionsExtension.cs
+++ b/src/EasyCaching.LiteDB/Configurations/LiteDBOptionsExtension.cs
@@ -44,7 +44,7 @@
 
             services.Configure(_name, configure);
 
-            services.TryAddSingleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>());
             services.AddSingleton<ILiteDBDatabaseProvider, LiteDBDatabaseProvider>(x =>
             {
                 var optionsMon = x.GetRequiredService<IOptionsMonitor<LiteDBOptions>>();

--- a/src/EasyCaching.Memcached/Configurations/MemcachedOptionsExtension.cs
+++ b/src/EasyCaching.Memcached/Configurations/MemcachedOptionsExtension.cs
@@ -47,7 +47,7 @@
 
             services.Configure(_name, configure);
 
-            services.TryAddSingleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>());
             services.TryAddSingleton<IMemcachedKeyTransformer, DefaultKeyTransformer>();
             services.TryAddSingleton<IEasyCachingSerializer, DefaultBinaryFormatterSerializer>();
             services.AddSingleton<EasyCachingTranscoder>(x =>

--- a/src/EasyCaching.Redis/Configurations/RedisOptionsExtension.cs
+++ b/src/EasyCaching.Redis/Configurations/RedisOptionsExtension.cs
@@ -49,7 +49,7 @@ namespace EasyCaching.Redis
 
             services.Configure(_name, configure);
 
-            services.TryAddSingleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>());
             services.AddSingleton<IRedisDatabaseProvider, RedisDatabaseProvider>(x =>
             {
                 var optionsMon = x.GetRequiredService<IOptionsMonitor<RedisOptions>>();

--- a/src/EasyCaching.SQLite/Configurations/SQLiteOptionsExtension.cs
+++ b/src/EasyCaching.SQLite/Configurations/SQLiteOptionsExtension.cs
@@ -44,7 +44,7 @@
 
             services.Configure(_name, configure);
 
-            services.TryAddSingleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IEasyCachingProviderFactory, DefaultEasyCachingProviderFactory>());
             services.AddSingleton<ISQLiteDatabaseProvider, SQLiteDatabaseProvider>(x =>
             {
                 var optionsMon = x.GetRequiredService<IOptionsMonitor<SQLiteOptions>>();


### PR DESCRIPTION
#359  this look like a bug
When i set a  serializer before provider,even though my provider has no serializer ,the default serializer  is can't be register.
like this
```
          services.AddEasyCaching(op =>
          {
		op.WithSystemTextJson();
		op.UseRedis(x =>
		{
			x.DBConfig.Endpoints.Add(new ServerEndPoint("localhost", 6379));
			x.DBConfig.Database = 0;
			x.DBConfig.Password = "";
			//x.SerializerName = "json";
		}, "Redis");
          });
```
If i set provider before serializer ,it's ok
like this
```
            services.AddEasyCaching(op =>
            {
				op.UseRedis(x =>
				{
					x.DBConfig.Endpoints.Add(new ServerEndPoint("localhost", 6379));
					x.DBConfig.Database = 0;
					x.DBConfig.Password = "";
					//x.SerializerName = "json";
				}, "Redis");
				op.WithSystemTextJson();
            });
```
So I changed AddSingleton into TryAddEnumerable to ensure binary serializer was registered


这可能是一个BUG
当我在设置provider之前注册了序列化器,即使之后我添加的provider没有序列化器,默认的序列化器也不会被添加到DI容器中
代码看起来像这样
```
          services.AddEasyCaching(op =>
          {
		op.WithSystemTextJson();
		op.UseRedis(x =>
		{
			x.DBConfig.Endpoints.Add(new ServerEndPoint("localhost", 6379));
			x.DBConfig.Database = 0;
			x.DBConfig.Password = "";
			//x.SerializerName = "json";
		}, "Redis");
          });
```
如果我反过来,先添加一个没有指定序列化器的provider,代码就正常工作
```
            services.AddEasyCaching(op =>
            {
				op.UseRedis(x =>
				{
					x.DBConfig.Endpoints.Add(new ServerEndPoint("localhost", 6379));
					x.DBConfig.Database = 0;
					x.DBConfig.Password = "";
					//x.SerializerName = "json";
				}, "Redis");
				op.WithSystemTextJson();
            });
```
所以我更改了注册方式保证默认的序列化器一定会被注册