### PR TITLE
optimization: more clear exception message for not found

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -1,24 +1,24 @@
 <Project>
 	<PropertyGroup>
-		<EasyCachingCorePackageVersion>1.5.2</EasyCachingCorePackageVersion>
-		<EasyCachingMemcachedPackageVersion>1.5.2</EasyCachingMemcachedPackageVersion>
-		<EasyCachingRedisPackageVersion>1.5.2</EasyCachingRedisPackageVersion>
-		<EasyCachingSQLitePackageVersion>1.5.2</EasyCachingSQLitePackageVersion>
-		<EasyCachingInMemoryPackageVersion>1.5.2</EasyCachingInMemoryPackageVersion>
-		<EasyCachingHybridPackageVersion>1.5.2</EasyCachingHybridPackageVersion>
-		<EasyCachingAspectCorePackageVersion>1.5.2</EasyCachingAspectCorePackageVersion>
-		<EasyCachingCastlePackageVersion>1.5.2</EasyCachingCastlePackageVersion>
-		<EasyCachingResponseCachingPackageVersion>1.5.2</EasyCachingResponseCachingPackageVersion>
-		<EasyCachingJsonPackageVersion>1.5.2</EasyCachingJsonPackageVersion>
-		<EasyCachingMessagePackPackageVersion>1.5.2</EasyCachingMessagePackPackageVersion>
-		<EasyCachingProtobufPackageVersion>1.5.2</EasyCachingProtobufPackageVersion>
-		<EasyCachingCSRedisPackageVersion>1.5.3</EasyCachingCSRedisPackageVersion>
-		<EasyCachingRedisBusPackageVersion>1.5.2</EasyCachingRedisBusPackageVersion>
-		<EasyCachingCSRedisBusPackageVersion>1.5.2</EasyCachingCSRedisBusPackageVersion>
-		<EasyCachingRabbitBusPackageVersion>1.5.2</EasyCachingRabbitBusPackageVersion>
-		<EasyCachingDiskPackageVersion>1.5.2</EasyCachingDiskPackageVersion>
-		<EasyCachingMsExtPackageVersion>1.5.2</EasyCachingMsExtPackageVersion>
-		<EasyCachingLiteDBPackageVersion>1.5.2</EasyCachingLiteDBPackageVersion>
-		<EasyCachingSTJsonPackageVersion>1.5.2</EasyCachingSTJsonPackageVersion>
+		<EasyCachingCorePackageVersion>1.6.0</EasyCachingCorePackageVersion>
+		<EasyCachingMemcachedPackageVersion>1.6.0</EasyCachingMemcachedPackageVersion>
+		<EasyCachingRedisPackageVersion>1.6.0</EasyCachingRedisPackageVersion>
+		<EasyCachingSQLitePackageVersion>1.6.0</EasyCachingSQLitePackageVersion>
+		<EasyCachingInMemoryPackageVersion>1.6.0</EasyCachingInMemoryPackageVersion>
+		<EasyCachingHybridPackageVersion>1.6.0</EasyCachingHybridPackageVersion>
+		<EasyCachingAspectCorePackageVersion>1.6.0</EasyCachingAspectCorePackageVersion>
+		<EasyCachingCastlePackageVersion>1.6.0</EasyCachingCastlePackageVersion>
+		<EasyCachingResponseCachingPackageVersion>1.6.0</EasyCachingResponseCachingPackageVersion>
+		<EasyCachingJsonPackageVersion>1.6.0</EasyCachingJsonPackageVersion>
+		<EasyCachingMessagePackPackageVersion>1.6.0</EasyCachingMessagePackPackageVersion>
+		<EasyCachingProtobufPackageVersion>1.6.0</EasyCachingProtobufPackageVersion>
+		<EasyCachingCSRedisPackageVersion>1.6.0</EasyCachingCSRedisPackageVersion>
+		<EasyCachingRedisBusPackageVersion>1.6.0</EasyCachingRedisBusPackageVersion>
+		<EasyCachingCSRedisBusPackageVersion>1.6.0</EasyCachingCSRedisBusPackageVersion>
+		<EasyCachingRabbitBusPackageVersion>1.6.0</EasyCachingRabbitBusPackageVersion>
+		<EasyCachingDiskPackageVersion>1.6.0</EasyCachingDiskPackageVersion>
+		<EasyCachingMsExtPackageVersion>1.6.0</EasyCachingMsExtPackageVersion>
+		<EasyCachingLiteDBPackageVersion>1.6.0</EasyCachingLiteDBPackageVersion>
+		<EasyCachingSTJsonPackageVersion>1.6.0</EasyCachingSTJsonPackageVersion>
 	</PropertyGroup>
 </Project>

--- a/src/EasyCaching.CSRedis/DefaultCSRedisCachingProvider.cs
+++ b/src/EasyCaching.CSRedis/DefaultCSRedisCachingProvider.cs
@@ -86,12 +86,15 @@
             this._name = name;
             this._options = options;
             this._logger = loggerFactory?.CreateLogger<DefaultCSRedisCachingProvider>();
-            this._cache = clients.Single(x => x.Name.Equals(_name));
+            this._cache = clients.FirstOrDefault(x => x.Name.Equals(_name));
+
+            if (this._cache == null) throw new EasyCachingNotFoundException(string.Format(EasyCachingConstValue.NotFoundCliExceptionMessage, _name));
+
             this._cacheStats = new CacheStats();
 
-            this._serializer = !string.IsNullOrWhiteSpace(options.SerializerName)
-                ? serializers.Single(x => x.Name.Equals(options.SerializerName))
-                : serializers.FirstOrDefault(x => x.Name.Equals(_name)) ?? serializers.Single(x => x.Name.Equals(EasyCachingConstValue.DefaultSerializerName));
+            var serName = !string.IsNullOrWhiteSpace(options.SerializerName) ? options.SerializerName : _name;
+            this._serializer = serializers.FirstOrDefault(x => x.Name.Equals(serName));
+            if (this._serializer == null) throw new EasyCachingNotFoundException(string.Format(EasyCachingConstValue.NotFoundSerExceptionMessage, serName));
 
             this.ProviderName = this._name;
             this.ProviderType = CachingProviderType.Redis;

--- a/src/EasyCaching.Core/EasyCachingException.cs
+++ b/src/EasyCaching.Core/EasyCachingException.cs
@@ -1,0 +1,20 @@
+﻿namespace EasyCaching.Core
+{
+    using System;
+
+    public class EasyCachingException : Exception
+    {
+        public EasyCachingException(string message)
+            : base(message)
+        {
+        }
+    }
+
+    public class EasyCachingNotFoundException : Exception
+    {
+        public EasyCachingNotFoundException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/EasyCaching.Core/Internal/EasyCachingConstValue.cs
+++ b/src/EasyCaching.Core/Internal/EasyCachingConstValue.cs
@@ -103,5 +103,9 @@
         /// The LiteDB Bus section.
         /// </summary>
         public const string LiteDBSection= "easycaching:litedb";
+
+        public const string NotFoundCliExceptionMessage = "Can not find the matched client instance, client name is {0}";
+
+        public const string NotFoundSerExceptionMessage = "Can not find the matched serializer instance, serializer name is {0}";
     }
 }

--- a/src/EasyCaching.LiteDB/DefaultLiteDBCachingProvider.cs
+++ b/src/EasyCaching.LiteDB/DefaultLiteDBCachingProvider.cs
@@ -52,7 +52,9 @@
             LiteDBOptions options,
            ILoggerFactory loggerFactory = null)
         {
-            this._dbProvider = dbProviders.Single(x => x.DBProviderName.Equals(name));
+            this._dbProvider = dbProviders.FirstOrDefault(x => x.DBProviderName.Equals(name));
+            if (this._dbProvider == null) throw new EasyCachingNotFoundException(string.Format(EasyCachingConstValue.NotFoundCliExceptionMessage, _name));
+
             this._options = options;
             this._logger = loggerFactory?.CreateLogger<DefaultLiteDBCachingProvider>();
             this._litedb = _dbProvider.GetConnection();

--- a/src/EasyCaching.Memcached/DefaultMemcachedCachingProvider.cs
+++ b/src/EasyCaching.Memcached/DefaultMemcachedCachingProvider.cs
@@ -77,7 +77,9 @@ using EasyCaching.Memcached.DistributedLock;
             : base(factory, options)
         {
             this._name = name;
-            this._memcachedClient = memcachedClients.Single(x => x.Name.Equals(this._name));
+            this._memcachedClient = memcachedClients.FirstOrDefault(x => x.Name.Equals(this._name));
+            if (this._memcachedClient == null) throw new EasyCachingNotFoundException(string.Format(EasyCachingConstValue.NotFoundCliExceptionMessage, _name));
+
             this._options = options;
             this._logger = loggerFactory?.CreateLogger<DefaultMemcachedCachingProvider>();
             this._cacheStats = new CacheStats();

--- a/test/EasyCaching.UnitTests/CachingTests/CSRedisCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/CSRedisCachingProviderTest.cs
@@ -33,7 +33,7 @@ namespace EasyCaching.UnitTests
                         }
                     };
                     additionalSetup(options);
-                }).UseCSRedisLock());
+                }).UseCSRedisLock().WithJson(EasyCachingConstValue.DefaultCSRedisName));
 
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             return serviceProvider.GetService<IEasyCachingProvider>();
@@ -91,18 +91,6 @@ namespace EasyCaching.UnitTests
 
                 }, "cs2");
 
-                option.UseCSRedis(config =>
-                {
-                    config.DBConfig = new CSRedisDBOptions
-                    {
-                        ConnectionStrings = new System.Collections.Generic.List<string>
-                        {
-                            "127.0.0.1:6388,defaultDatabase=3,poolsize=10"
-                        }
-                    };
-
-                }, "cs3");
-
                 option.WithJson("json").WithMessagePack("cs11").WithJson("cs2");
             });
 
@@ -115,15 +103,12 @@ namespace EasyCaching.UnitTests
         {
             var cs1 = _providerFactory.GetCachingProvider("cs1");
             var cs2 = _providerFactory.GetCachingProvider("cs2");
-            var cs3 = _providerFactory.GetCachingProvider("cs3");
 
             var info1 = cs1.GetProviderInfo();
             var info2 = cs2.GetProviderInfo();
-            var info3 = cs3.GetProviderInfo();
 
             Assert.Equal("cs11", info1.Serializer.Name);
             Assert.Equal("cs2", info2.Serializer.Name);
-            Assert.Equal(EasyCachingConstValue.DefaultSerializerName, info3.Serializer.Name);
         }
     }
 

--- a/test/EasyCaching.UnitTests/CachingTests/CSRedisFeatureCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/CSRedisFeatureCachingProviderTest.cs
@@ -12,6 +12,7 @@
             IServiceCollection services = new ServiceCollection();
             services.AddEasyCaching(option =>
             {
+                option.WithJson("ser");
                 option.UseCSRedis(config =>
                 {
                     config.DBConfig = new CSRedisDBOptions
@@ -21,6 +22,7 @@
                             "127.0.0.1:6388,defaultDatabase=10,poolsize=10"
                         }
                     };
+                    config.SerializerName = "ser";
                 });
             });
 

--- a/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
@@ -49,7 +49,7 @@
                 {
                     config.DBConfig.Endpoints.Add(new Core.Configurations.ServerEndPoint("127.0.0.1", 6379));
                     config.DBConfig.Database = 5;
-                }, "myredis");
+                }, "myredis").WithJson("myredis");
 
                 option.UseHybrid(config =>
                 {
@@ -63,6 +63,7 @@
                 {
                     config.Endpoints.Add(new Core.Configurations.ServerEndPoint("127.0.0.1", 6379));
                     config.Database = 6;
+                    config.SerializerName = "myredis";
                 });
             });
 

--- a/test/EasyCaching.UnitTests/CachingTests/RedisCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/RedisCachingProviderTest.cs
@@ -32,7 +32,7 @@ namespace EasyCaching.UnitTests
                     options.DBConfig.Endpoints.Add(new ServerEndPoint("127.0.0.1", 6380));
                     options.DBConfig.Database = 5;
                     additionalSetup(options);
-                }, ProviderName).UseRedisLock());
+                }, ProviderName).UseRedisLock().WithJson(ProviderName));
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             return serviceProvider.GetService<IEasyCachingProvider>();
         }
@@ -49,7 +49,7 @@ namespace EasyCaching.UnitTests
             IServiceCollection services = new ServiceCollection();
             services.AddEasyCaching(x =>
                 x.UseRedis(options => { options.DBConfig.Endpoints.Add(new ServerEndPoint("127.0.0.1", 6380)); },
-                    ProviderName)
+                    ProviderName).WithJson(ProviderName)
             );
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             var factory = serviceProvider.GetRequiredService<IEasyCachingProviderFactory>();
@@ -88,7 +88,7 @@ namespace EasyCaching.UnitTests
                 x.UseRedis(options =>
                 {
                     options.DBConfig.Configuration = "127.0.0.1:6380,allowAdmin=false,defaultdatabase=8";
-                }));
+                }, ProviderName).WithJson(ProviderName));
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             var dbProvider = serviceProvider.GetService<IRedisDatabaseProvider>();
             Assert.NotNull(dbProvider);
@@ -122,6 +122,8 @@ namespace EasyCaching.UnitTests
             IServiceCollection services = new ServiceCollection();
             services.AddEasyCaching(x =>
             {
+                x.WithJson("ser");
+
                 x.UseRedis(options =>
                 {
                     options.DBConfig = new RedisDBOptions
@@ -130,6 +132,7 @@ namespace EasyCaching.UnitTests
                     };
                     options.DBConfig.Endpoints.Add(new ServerEndPoint("127.0.0.1", 6380));
                     options.DBConfig.Database = 3;
+                    options.SerializerName = "ser";
                 });
 
 
@@ -141,6 +144,7 @@ namespace EasyCaching.UnitTests
                     };
                     options.DBConfig.Endpoints.Add(new ServerEndPoint("127.0.0.1", 6380));
                     options.DBConfig.Database = 4;
+                    options.SerializerName = "ser";
                 }, SECOND_PROVIDER_NAME);
             });
             IServiceProvider serviceProvider = services.BuildServiceProvider();
@@ -183,16 +187,6 @@ namespace EasyCaching.UnitTests
                     options.DBConfig.Database = 14;
                 }, "se2");
 
-                x.UseRedis(options =>
-                {
-                    options.DBConfig = new RedisDBOptions
-                    {
-                        AllowAdmin = true
-                    };
-                    options.DBConfig.Endpoints.Add(new ServerEndPoint("127.0.0.1", 6380));
-                    options.DBConfig.Database = 11;
-                }, "se3");
-
                 x.WithJson("json").WithMessagePack("cs11").WithJson("se2");
             });
 
@@ -205,15 +199,12 @@ namespace EasyCaching.UnitTests
         {
             var se1 = _providerFactory.GetCachingProvider("se1");
             var se2 = _providerFactory.GetCachingProvider("se2");
-            var se3 = _providerFactory.GetCachingProvider("se3");
 
             var info1 = se1.GetProviderInfo();
             var info2 = se2.GetProviderInfo();
-            var info3 = se3.GetProviderInfo();
 
             Assert.Equal("cs11", info1.Serializer.Name);
             Assert.Equal("se2", info2.Serializer.Name);
-            Assert.Equal(EasyCachingConstValue.DefaultSerializerName, info3.Serializer.Name);
         }
     }
 

--- a/test/EasyCaching.UnitTests/CachingTests/SERedisFeatureCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/SERedisFeatureCachingProviderTest.cs
@@ -25,7 +25,7 @@
                     };
                     config.DBConfig.Endpoints.Add(new ServerEndPoint("127.0.0.1", 6380));
                     config.DBConfig.Database = 10;
-                });
+                }).WithJson(EasyCachingConstValue.DefaultRedisName);
             });
 
             IServiceProvider serviceProvider = services.BuildServiceProvider();

--- a/test/EasyCaching.UnitTests/DistributedLock/CSRedisLockTest.cs
+++ b/test/EasyCaching.UnitTests/DistributedLock/CSRedisLockTest.cs
@@ -21,7 +21,7 @@ namespace EasyCaching.UnitTests.DistributedLock
                         }
                     };
                 })
-                .UseCSRedisLock())
+                .UseCSRedisLock().WithJson(EasyCachingConstValue.DefaultCSRedisName))
             .BuildServiceProvider()
             .GetService<CSRedisLockFactory>();
 

--- a/test/EasyCaching.UnitTests/DistributedLock/RedisLockTest.cs
+++ b/test/EasyCaching.UnitTests/DistributedLock/RedisLockTest.cs
@@ -22,7 +22,7 @@ namespace EasyCaching.UnitTests.DistributedLock
                         }
                     };
                 })
-                .UseRedisLock())
+                .UseRedisLock().WithJson(EasyCachingConstValue.DefaultRedisName))
             .BuildServiceProvider()
             .GetService<RedisLockFactory>();
 

--- a/test/EasyCaching.UnitTests/ProviderFactoryTests.cs
+++ b/test/EasyCaching.UnitTests/ProviderFactoryTests.cs
@@ -25,6 +25,8 @@
             IServiceCollection services = new ServiceCollection();
             services.AddEasyCaching(option =>
             {
+                option.WithJson("redis1");
+                option.WithJson("redis2");
                 option.UseRedis(config =>
                 {
                     config.DBConfig = new RedisDBOptions


### PR DESCRIPTION
1. caching client instance  not found exception message
2. serializer instance  not found exception message
3. remove `DefaultSerializer` from distributed caching when not specify the serializer name or not match client instance name, prepare to remove BinaryFormatter for the next version.

