### PR TITLE
missing CancellationToken implemented

### DIFF
--- a/src/EasyCaching.CSRedis/DefaultCSRedisCachingProvider.Async.cs
+++ b/src/EasyCaching.CSRedis/DefaultCSRedisCachingProvider.Async.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using EasyCaching.Core;
     using global::CSRedis;
@@ -14,32 +15,35 @@
         /// </summary>
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
-        public override async Task<bool> BaseExistsAsync(string cacheKey)
+        /// <param name="cancellationToken">CancellationToken</param>
+        public override async Task<bool> BaseExistsAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
             return await _cache.ExistsAsync(cacheKey);
         }
-      
+
         /// <summary>
         /// Flushs the async.
         /// </summary>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <returns>The async.</returns>
-        public override async Task BaseFlushAsync()
+        public override async Task BaseFlushAsync(CancellationToken cancellationToken = default)
         {
             if (_options.EnableLogging)
                 _logger?.LogInformation("Redis -- FlushAsync");
 
             await _cache.NodesServerManager.FlushDbAsync();
         }
-     
+
         /// <summary>
         /// Gets all async.
         /// </summary>
         /// <returns>The all async.</returns>
         /// <param name="cacheKeys">Cache keys.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public override async Task<IDictionary<string, CacheValue<T>>> BaseGetAllAsync<T>(IEnumerable<string> cacheKeys)
+        public override async Task<IDictionary<string, CacheValue<T>>> BaseGetAllAsync<T>(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullAndCountGTZero(cacheKeys, nameof(cacheKeys));
 
@@ -67,8 +71,9 @@
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="dataRetriever">Data retriever.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public override async Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration)
+        public override async Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNegativeOrZero(expiration, nameof(expiration));
@@ -120,7 +125,8 @@
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="type">Object Type.</param>
-        public override async Task<object> BaseGetAsync(string cacheKey, Type type)
+        /// <param name="cancellationToken">CancellationToken</param>
+        public override async Task<object> BaseGetAsync(string cacheKey, Type type, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
@@ -151,8 +157,9 @@
         /// </summary>
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public override async Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey)
+        public override async Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
@@ -183,7 +190,8 @@
         /// </summary>
         /// <returns>The count.</returns>
         /// <param name="prefix">Prefix.</param>
-        public override Task<int> BaseGetCountAsync(string prefix = "")
+        /// <param name="cancellationToken">CancellationToken</param>
+        public override Task<int> BaseGetCountAsync(string prefix = "", CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(prefix))
             {
@@ -207,8 +215,9 @@
         /// </summary>
         /// <returns>The by prefix async.</returns>
         /// <param name="prefix">Prefix.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public override async Task<IDictionary<string, CacheValue<T>>> BaseGetByPrefixAsync<T>(string prefix)
+        public override async Task<IDictionary<string, CacheValue<T>>> BaseGetByPrefixAsync<T>(string prefix, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(prefix, nameof(prefix));
 
@@ -229,13 +238,14 @@
 
             return result;
         }
-    
+
         /// <summary>
         /// Removes all async.
         /// </summary>
         /// <returns>The all async.</returns>
         /// <param name="cacheKeys">Cache keys.</param>
-        public override async Task BaseRemoveAllAsync(IEnumerable<string> cacheKeys)
+        /// <param name="cancellationToken">CancellationToken</param>
+        public override async Task BaseRemoveAllAsync(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullAndCountGTZero(cacheKeys, nameof(cacheKeys));
 
@@ -254,19 +264,21 @@
         /// </summary>
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
-        public override async Task BaseRemoveAsync(string cacheKey)
+        /// <param name="cancellationToken">CancellationToken</param>
+        public override async Task BaseRemoveAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
             await _cache.DelAsync(cacheKey);
-        }     
+        }
 
         /// <summary>
         /// Removes the by prefix async.
         /// </summary>
         /// <returns>The by prefix async.</returns>
         /// <param name="prefix">Prefix.</param>
-        public override async Task BaseRemoveByPrefixAsync(string prefix)
+        /// <param name="cancellationToken">CancellationToken</param>
+        public override async Task BaseRemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(prefix, nameof(prefix));
 
@@ -293,8 +305,9 @@
         /// <returns>The all async.</returns>
         /// <param name="value">Value.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public override async Task BaseSetAllAsync<T>(IDictionary<string, T> value, TimeSpan expiration)
+        public override async Task BaseSetAllAsync<T>(IDictionary<string, T> value, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             //whether to use pipe based on redis mode 
             var tasks = new List<Task<bool>>();
@@ -320,8 +333,9 @@
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="cacheValue">Cache value.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public override async Task BaseSetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public override async Task BaseSetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNull(cacheValue, nameof(cacheValue), _options.CacheNulls);
@@ -349,8 +363,9 @@
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="cacheValue">Cache value.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public override async Task<bool> BaseTrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public override async Task<bool> BaseTrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNull(cacheValue, nameof(cacheValue), _options.CacheNulls);
@@ -374,8 +389,9 @@
         /// Get the expiration of cache key async
         /// </summary>
         /// <param name="cacheKey">cache key</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <returns>expiration</returns>
-        public override async Task<TimeSpan> BaseGetExpirationAsync(string cacheKey)
+        public override async Task<TimeSpan> BaseGetExpirationAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 

--- a/src/EasyCaching.Core/EasyCachingAbstractProvider.cs
+++ b/src/EasyCaching.Core/EasyCachingAbstractProvider.cs
@@ -6,6 +6,7 @@ namespace EasyCaching.Core
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using EasyCaching.Core.Configurations;
     using EasyCaching.Core.Diagnostics;
@@ -43,35 +44,35 @@ namespace EasyCaching.Core
 
         public abstract object BaseGetDatabse();
         public abstract bool BaseExists(string cacheKey);
-        public abstract Task<bool> BaseExistsAsync(string cacheKey);
+        public abstract Task<bool> BaseExistsAsync(string cacheKey, CancellationToken cancellationToken = default);
         public abstract void BaseFlush();
-        public abstract Task BaseFlushAsync();
+        public abstract Task BaseFlushAsync(CancellationToken cancellationToken = default);
         public abstract CacheValue<T> BaseGet<T>(string cacheKey, Func<T> dataRetriever, TimeSpan expiration);
         public abstract CacheValue<T> BaseGet<T>(string cacheKey);
         public abstract IDictionary<string, CacheValue<T>> BaseGetAll<T>(IEnumerable<string> cacheKeys);
-        public abstract Task<IDictionary<string, CacheValue<T>>> BaseGetAllAsync<T>(IEnumerable<string> cacheKeys);
-        public abstract Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration);
-        public abstract Task<object> BaseGetAsync(string cacheKey, Type type);
-        public abstract Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey);
+        public abstract Task<IDictionary<string, CacheValue<T>>> BaseGetAllAsync<T>(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default);
+        public abstract Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration, CancellationToken cancellationToken = default);
+        public abstract Task<object> BaseGetAsync(string cacheKey, Type type, CancellationToken cancellationToken = default);
+        public abstract Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey, CancellationToken cancellationToken = default);
         public abstract IDictionary<string, CacheValue<T>> BaseGetByPrefix<T>(string prefix);
-        public abstract Task<IDictionary<string, CacheValue<T>>> BaseGetByPrefixAsync<T>(string prefix);
+        public abstract Task<IDictionary<string, CacheValue<T>>> BaseGetByPrefixAsync<T>(string prefix, CancellationToken cancellationToken = default);
         public abstract int BaseGetCount(string prefix = "");
-        public abstract Task<int> BaseGetCountAsync(string prefix = "");
+        public abstract Task<int> BaseGetCountAsync(string prefix = "", CancellationToken cancellationToken = default);
         public abstract void BaseRemove(string cacheKey);
         public abstract void BaseRemoveAll(IEnumerable<string> cacheKeys);
-        public abstract Task BaseRemoveAllAsync(IEnumerable<string> cacheKeys);
-        public abstract Task BaseRemoveAsync(string cacheKey);
+        public abstract Task BaseRemoveAllAsync(IEnumerable<string> cacheKeys, CancellationToken cancellation = default);
+        public abstract Task BaseRemoveAsync(string cacheKey, CancellationToken cancellationToken = default);
         public abstract void BaseRemoveByPrefix(string prefix);
-        public abstract Task BaseRemoveByPrefixAsync(string prefix);
+        public abstract Task BaseRemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default);
         public abstract void BaseSet<T>(string cacheKey, T cacheValue, TimeSpan expiration);
         public abstract void BaseSetAll<T>(IDictionary<string, T> values, TimeSpan expiration);
-        public abstract Task BaseSetAllAsync<T>(IDictionary<string, T> values, TimeSpan expiration);
-        public abstract Task BaseSetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration);
+        public abstract Task BaseSetAllAsync<T>(IDictionary<string, T> values, TimeSpan expiration, CancellationToken cancellationToken = default);
+        public abstract Task BaseSetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default);
         public abstract bool BaseTrySet<T>(string cacheKey, T cacheValue, TimeSpan expiration);
-        public abstract Task<bool> BaseTrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration);
+        public abstract Task<bool> BaseTrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default);
 
         public abstract TimeSpan BaseGetExpiration(string cacheKey);
-        public abstract Task<TimeSpan> BaseGetExpirationAsync(string cacheKey);
+        public abstract Task<TimeSpan> BaseGetExpirationAsync(string cacheKey, CancellationToken cancellationToken = default);
         public abstract ProviderInfo BaseGetProviderInfo();
 
         public bool Exists(string cacheKey)
@@ -100,13 +101,13 @@ namespace EasyCaching.Core
             }
         }
 
-        public async Task<bool> ExistsAsync(string cacheKey)
+        public async Task<bool> ExistsAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             var operationId = s_diagnosticListener.WriteExistsCacheBefore(new BeforeExistsRequestEventData(CachingProviderType.ToString(), Name, nameof(ExistsAsync), cacheKey));
             Exception e = null;
             try
             {
-                var flag = await BaseExistsAsync(cacheKey);
+                var flag = await BaseExistsAsync(cacheKey, cancellationToken);
                 return flag;
             }
             catch (Exception ex)
@@ -153,13 +154,13 @@ namespace EasyCaching.Core
             }
         }
 
-        public async Task FlushAsync()
+        public async Task FlushAsync(CancellationToken cancellationToken = default)
         {
             var operationId = s_diagnosticListener.WriteFlushCacheBefore(new EventData(CachingProviderType.ToString(), Name, nameof(FlushAsync)));
             Exception e = null;
             try
             {
-                await BaseFlushAsync();
+                await BaseFlushAsync(cancellationToken);
             }
             catch (Exception ex)
             {
@@ -280,13 +281,13 @@ namespace EasyCaching.Core
             }
         }
 
-        public async Task<IDictionary<string, CacheValue<T>>> GetAllAsync<T>(IEnumerable<string> cacheKeys)
+        public async Task<IDictionary<string, CacheValue<T>>> GetAllAsync<T>(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
             var operationId = s_diagnosticListener.WriteGetCacheBefore(new BeforeGetRequestEventData(CachingProviderType.ToString(), Name, nameof(GetAllAsync), cacheKeys.ToArray()));
             Exception e = null;
             try
             {
-                return await BaseGetAllAsync<T>(cacheKeys);
+                return await BaseGetAllAsync<T>(cacheKeys, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -306,13 +307,13 @@ namespace EasyCaching.Core
             }
         }
 
-        public async Task<CacheValue<T>> GetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration)
+        public async Task<CacheValue<T>> GetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             var operationId = s_diagnosticListener.WriteGetCacheBefore(new BeforeGetRequestEventData(CachingProviderType.ToString(), Name, nameof(GetAsync), new[] { cacheKey }, expiration));
             Exception e = null;
             try
             {
-                if (_lockFactory == null) return await BaseGetAsync<T>(cacheKey, dataRetriever, expiration);
+                if (_lockFactory == null) return await BaseGetAsync<T>(cacheKey, dataRetriever, expiration, cancellationToken);
 
                 var value = await BaseGetAsync<T>(cacheKey);
                 if (value.HasValue) return value;
@@ -322,7 +323,7 @@ namespace EasyCaching.Core
                 {
                     if (!await @lock.LockAsync(_options.SleepMs)) throw new TimeoutException();
 
-                    value = await BaseGetAsync<T>(cacheKey);
+                    value = await BaseGetAsync<T>(cacheKey, cancellationToken);
                     if (value.HasValue) return value;
 
                     var task = dataRetriever();
@@ -333,7 +334,7 @@ namespace EasyCaching.Core
                     var item = await task;
                     if (item != null || _options.CacheNulls)
                     {
-                        await BaseSetAsync(cacheKey, item, expiration);
+                        await BaseSetAsync(cacheKey, item, expiration, cancellationToken);
 
                         return new CacheValue<T>(item, true);
                     }
@@ -365,13 +366,13 @@ namespace EasyCaching.Core
             }
         }
 
-        public async Task<object> GetAsync(string cacheKey, Type type)
+        public async Task<object> GetAsync(string cacheKey, Type type, CancellationToken cancellationToken = default)
         {
             var operationId = s_diagnosticListener.WriteGetCacheBefore(new BeforeGetRequestEventData(CachingProviderType.ToString(), Name, "GetAsync_Type", new[] { cacheKey }));
             Exception e = null;
             try
             {
-                return await BaseGetAsync(cacheKey, type);
+                return await BaseGetAsync(cacheKey, type, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -391,13 +392,13 @@ namespace EasyCaching.Core
             }
         }
 
-        public async Task<CacheValue<T>> GetAsync<T>(string cacheKey)
+        public async Task<CacheValue<T>> GetAsync<T>(string cacheKey, CancellationToken cancellationToken = default)
         {
             var operationId = s_diagnosticListener.WriteGetCacheBefore(new BeforeGetRequestEventData(CachingProviderType.ToString(), Name, nameof(GetAsync), new[] { cacheKey }));
             Exception e = null;
             try
             {
-                return await BaseGetAsync<T>(cacheKey);
+                return await BaseGetAsync<T>(cacheKey, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -443,13 +444,13 @@ namespace EasyCaching.Core
             }
         }
 
-        public async Task<IDictionary<string, CacheValue<T>>> GetByPrefixAsync<T>(string prefix)
+        public async Task<IDictionary<string, CacheValue<T>>> GetByPrefixAsync<T>(string prefix, CancellationToken cancellationToken = default)
         {
             var operationId = s_diagnosticListener.WriteGetCacheBefore(new BeforeGetRequestEventData(CachingProviderType.ToString(), Name, nameof(GetByPrefixAsync), new[] { prefix }));
             Exception e = null;
             try
             {
-                return await BaseGetByPrefixAsync<T>(prefix);
+                return await BaseGetByPrefixAsync<T>(prefix, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -474,9 +475,9 @@ namespace EasyCaching.Core
             return BaseGetCount(prefix);
         }
 
-        public async Task<int> GetCountAsync(string prefix = "")
+        public async Task<int> GetCountAsync(string prefix = "", CancellationToken cancellationToken = default)
         {
-            return await BaseGetCountAsync(prefix);
+            return await BaseGetCountAsync(prefix, cancellationToken);
         }
 
         public void Remove(string cacheKey)
@@ -531,13 +532,13 @@ namespace EasyCaching.Core
             }
         }
 
-        public async Task RemoveAllAsync(IEnumerable<string> cacheKeys)
+        public async Task RemoveAllAsync(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
             var operationId = s_diagnosticListener.WriteRemoveCacheBefore(new BeforeRemoveRequestEventData(CachingProviderType.ToString(), Name, nameof(RemoveAllAsync), cacheKeys.ToArray()));
             Exception e = null;
             try
             {
-                await BaseRemoveAllAsync(cacheKeys);
+                await BaseRemoveAllAsync(cacheKeys, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -557,13 +558,13 @@ namespace EasyCaching.Core
             }
         }
 
-        public async Task RemoveAsync(string cacheKey)
+        public async Task RemoveAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             var operationId = s_diagnosticListener.WriteRemoveCacheBefore(new BeforeRemoveRequestEventData(CachingProviderType.ToString(), Name, nameof(RemoveAsync), new[] { cacheKey }));
             Exception e = null;
             try
             {
-                await BaseRemoveAsync(cacheKey);
+                await BaseRemoveAsync(cacheKey, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -609,13 +610,13 @@ namespace EasyCaching.Core
             }
         }
 
-        public async Task RemoveByPrefixAsync(string prefix)
+        public async Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
         {
             var operationId = s_diagnosticListener.WriteRemoveCacheBefore(new BeforeRemoveRequestEventData(CachingProviderType.ToString(), Name, nameof(RemoveByPrefixAsync), new[] { prefix }));
             Exception e = null;
             try
             {
-                await BaseRemoveByPrefixAsync(prefix);
+                await BaseRemoveByPrefixAsync(prefix, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -687,13 +688,13 @@ namespace EasyCaching.Core
             }
         }
 
-        public async Task SetAllAsync<T>(IDictionary<string, T> value, TimeSpan expiration)
+        public async Task SetAllAsync<T>(IDictionary<string, T> value, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             var operationId = s_diagnosticListener.WriteSetCacheBefore(new BeforeSetRequestEventData(CachingProviderType.ToString(), Name, nameof(SetAllAsync), value.ToDictionary(k => k.Key, v => (object)v.Value), expiration));
             Exception e = null;
             try
             {
-                await BaseSetAllAsync(value, expiration);
+                await BaseSetAllAsync(value, expiration, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -713,13 +714,13 @@ namespace EasyCaching.Core
             }
         }
 
-        public async Task SetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public async Task SetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             var operationId = s_diagnosticListener.WriteSetCacheBefore(new BeforeSetRequestEventData(CachingProviderType.ToString(), Name, nameof(SetAsync), new Dictionary<string, object> { { cacheKey, cacheValue } }, expiration));
             Exception e = null;
             try
             {
-                await BaseSetAsync(cacheKey, cacheValue, expiration);
+                await BaseSetAsync(cacheKey, cacheValue, expiration, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -765,13 +766,13 @@ namespace EasyCaching.Core
             }
         }
 
-        public async Task<bool> TrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public async Task<bool> TrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             var operationId = s_diagnosticListener.WriteSetCacheBefore(new BeforeSetRequestEventData(CachingProviderType.ToString(), Name, nameof(TrySetAsync), new Dictionary<string, object> { { cacheKey, cacheValue } }, expiration));
             Exception e = null;
             try
             {
-                return await BaseTrySetAsync(cacheKey, cacheValue, expiration);
+                return await BaseTrySetAsync(cacheKey, cacheValue, expiration, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -796,9 +797,9 @@ namespace EasyCaching.Core
             return BaseGetExpiration(cacheKey);
         }
 
-        public async Task<TimeSpan> GetExpirationAsync(string cacheKey)
+        public async Task<TimeSpan> GetExpirationAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
-            return await BaseGetExpirationAsync(cacheKey);
+            return await BaseGetExpirationAsync(cacheKey, cancellationToken);
         }
 
         public ProviderInfo GetProviderInfo()

--- a/src/EasyCaching.Core/IEasyCachingProvider.cs
+++ b/src/EasyCaching.Core/IEasyCachingProvider.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -34,8 +35,9 @@
         /// </summary>
         /// <returns>The all async.</returns>
         /// <param name="cacheKeys">Cache keys.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        Task<IDictionary<string, CacheValue<T>>> GetAllAsync<T>(IEnumerable<string> cacheKeys);
+        Task<IDictionary<string, CacheValue<T>>> GetAllAsync<T>(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the by prefix.
@@ -50,8 +52,9 @@
         /// </summary>
         /// <returns>The by prefix async.</returns>
         /// <param name="prefix">Prefix.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        Task<IDictionary<string, CacheValue<T>>> GetByPrefixAsync<T>(string prefix);
+        Task<IDictionary<string, CacheValue<T>>> GetByPrefixAsync<T>(string prefix, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the count.
@@ -65,7 +68,8 @@
         /// </summary>
         /// <returns>The count.</returns>
         /// <param name="prefix">Prefix.</param>
-        Task<int> GetCountAsync(string prefix = "");
+        /// <param name="cancellationToken">CancellationToken</param>
+        Task<int> GetCountAsync(string prefix = "", CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Flush All Cached Item.
@@ -76,7 +80,8 @@
         /// Flush All Cached Item async.
         /// </summary>
         /// <returns>The async.</returns>
-        Task FlushAsync();
+        /// <param name="cancellationToken">CancellationToken</param>
+        Task FlushAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the max rd second.
@@ -107,8 +112,9 @@
         /// Gets the exporation of specify cachekey async.
         /// </summary>
         /// <param name="cacheKey"></param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <returns></returns>
-        Task<TimeSpan> GetExpirationAsync(string cacheKey);
+        Task<TimeSpan> GetExpirationAsync(string cacheKey, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the information of provider.

--- a/src/EasyCaching.Core/IEasyCachingProviderBase.cs
+++ b/src/EasyCaching.Core/IEasyCachingProviderBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace EasyCaching.Core
@@ -28,8 +29,9 @@ namespace EasyCaching.Core
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="cacheValue">Cache value.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken"></param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        Task SetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration);
+        Task SetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get the specified cacheKey.
@@ -44,8 +46,9 @@ namespace EasyCaching.Core
         /// </summary>
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
+        /// <param name="cancellationToken"></param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        Task<CacheValue<T>> GetAsync<T>(string cacheKey);
+        Task<CacheValue<T>> GetAsync<T>(string cacheKey, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Remove the specified cacheKey.
@@ -58,14 +61,16 @@ namespace EasyCaching.Core
         /// </summary>
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
-        Task RemoveAsync(string cacheKey);
+        /// <param name="cancellationToken"></param>
+        Task RemoveAsync(string cacheKey, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Exists the specified cacheKey async.
         /// </summary>
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
-        Task<bool> ExistsAsync(string cacheKey);
+        /// <param name="cancellationToken"></param>
+        Task<bool> ExistsAsync(string cacheKey, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Exists the specified cacheKey.
@@ -91,8 +96,9 @@ namespace EasyCaching.Core
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="cacheValue">Cache value.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken"></param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        Task<bool> TrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration);
+        Task<bool> TrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Sets all.
@@ -108,8 +114,9 @@ namespace EasyCaching.Core
         /// <returns>The all async.</returns>
         /// <param name="value">Value.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken"></param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        Task SetAllAsync<T>(IDictionary<string, T> value, TimeSpan expiration);
+        Task SetAllAsync<T>(IDictionary<string, T> value, TimeSpan expiration, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Removes all.
@@ -122,7 +129,8 @@ namespace EasyCaching.Core
         /// </summary>
         /// <returns>The all async.</returns>
         /// <param name="cacheKeys">Cache keys.</param>
-        Task RemoveAllAsync(IEnumerable<string> cacheKeys);
+        /// <param name="cancellationToken"></param>
+        Task RemoveAllAsync(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get the specified cacheKey, dataRetriever and expiration.
@@ -141,8 +149,9 @@ namespace EasyCaching.Core
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="dataRetriever">Data retriever.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken"></param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        Task<CacheValue<T>> GetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration);
+        Task<CacheValue<T>> GetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Removes cached item by cachekey's prefix.
@@ -154,7 +163,8 @@ namespace EasyCaching.Core
         /// Removes cached item by cachekey's prefix async.
         /// </summary>
         /// <param name="prefix">Prefix of CacheKey.</param>
-        Task RemoveByPrefixAsync(string prefix);
+        /// <param name="cancellationToken"></param>
+        Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the specified cacheKey async.
@@ -162,6 +172,7 @@ namespace EasyCaching.Core
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="type">Object Type.</param>
-        Task<object> GetAsync(string cacheKey, Type type);
+        /// <param name="cancellationToken"></param>
+        Task<object> GetAsync(string cacheKey, Type type, CancellationToken cancellationToken = default);
     }
 }

--- a/src/EasyCaching.HybridCache/HybridCachingProvider.cs
+++ b/src/EasyCaching.HybridCache/HybridCachingProvider.cs
@@ -188,7 +188,7 @@
             // Circuit Breaker may be more better
             try
             {
-                flag = await _distributedCache.ExistsAsync(cacheKey);
+                flag = await _distributedCache.ExistsAsync(cacheKey, cancellationToken);
                 return flag;
             }
             catch (Exception ex)
@@ -196,7 +196,7 @@
                 LogMessage($"Check cache key [{cacheKey}] exists error", ex);
             }
 
-            flag = await _localCache.ExistsAsync(cacheKey);
+            flag = await _localCache.ExistsAsync(cacheKey, cancellationToken);
             return flag;
         }
 
@@ -205,7 +205,6 @@
         /// </summary>
         /// <returns>The get.</returns>
         /// <param name="cacheKey">Cache key.</param>
-        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
         public CacheValue<T> Get<T>(string cacheKey)
         {

--- a/src/EasyCaching.HybridCache/HybridCachingProvider.cs
+++ b/src/EasyCaching.HybridCache/HybridCachingProvider.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using EasyCaching.Core;
     using EasyCaching.Core.Bus;
@@ -177,7 +178,8 @@
         /// </summary>
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
-        public async Task<bool> ExistsAsync(string cacheKey)
+        /// <param name="cancellationToken">CancellationToken</param>
+        public async Task<bool> ExistsAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
@@ -203,6 +205,7 @@
         /// </summary>
         /// <returns>The get.</returns>
         /// <param name="cacheKey">Cache key.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
         public CacheValue<T> Get<T>(string cacheKey)
         {
@@ -246,12 +249,13 @@
         /// </summary>
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public async Task<CacheValue<T>> GetAsync<T>(string cacheKey)
+        public async Task<CacheValue<T>> GetAsync<T>(string cacheKey, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
-            var cacheValue = await _localCache.GetAsync<T>(cacheKey);
+            var cacheValue = await _localCache.GetAsync<T>(cacheKey, cancellationToken);
 
             if (cacheValue.HasValue)
             {
@@ -262,7 +266,7 @@
 
             try
             {
-                cacheValue = await _distributedCache.GetAsync<T>(cacheKey);
+                cacheValue = await _distributedCache.GetAsync<T>(cacheKey, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -271,9 +275,9 @@
 
             if (cacheValue.HasValue)
             {
-                TimeSpan ts = await GetExpirationAsync(cacheKey);
+                TimeSpan ts = await GetExpirationAsync(cacheKey, cancellationToken);
 
-                await _localCache.SetAsync(cacheKey, cacheValue.Value, ts);
+                await _localCache.SetAsync(cacheKey, cacheValue.Value, ts, cancellationToken);
 
                 return cacheValue;
             }
@@ -312,24 +316,25 @@
         /// </summary>
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
-        public async Task RemoveAsync(string cacheKey)
+        /// <param name="cancellationToken">CancellationToken</param>
+        public async Task RemoveAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
             try
             {
                 // distributed cache at first
-                await _distributedCache.RemoveAsync(cacheKey);
+                await _distributedCache.RemoveAsync(cacheKey, cancellationToken);
             }
             catch (Exception ex)
             {
                 LogMessage($"remove cache key [{cacheKey}] error", ex);
             }
 
-            await _localCache.RemoveAsync(cacheKey);
+            await _localCache.RemoveAsync(cacheKey, cancellationToken);
 
             // send message to bus 
-            await _busAsyncWrap.ExecuteAsync(async () => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = new string[] { cacheKey } }));
+            await _busAsyncWrap.ExecuteAsync(async (ct) => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = new string[] { cacheKey } }, ct), cancellationToken);
         }
 
         /// <summary>
@@ -365,16 +370,17 @@
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="cacheValue">Cache value.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public async Task SetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public async Task SetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
-            await _localCache.SetAsync(cacheKey, cacheValue, expiration);
+            await _localCache.SetAsync(cacheKey, cacheValue, expiration, cancellationToken);
 
             try
             {
-                await _distributedCache.SetAsync(cacheKey, cacheValue, expiration);
+                await _distributedCache.SetAsync(cacheKey, cacheValue, expiration, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -382,7 +388,7 @@
             }
 
             // When create/update cache, send message to bus so that other clients can remove it.
-            await _busAsyncWrap.ExecuteAsync(async () => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = new string[] { cacheKey } }));
+            await _busAsyncWrap.ExecuteAsync(async (ct) => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = new string[] { cacheKey } }, ct), cancellationToken);
         }
 
         /// <summary>
@@ -439,8 +445,9 @@
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="cacheValue">Cache value.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public async Task<bool> TrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public async Task<bool> TrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
@@ -449,7 +456,7 @@
 
             try
             {
-                flag = await _distributedCache.TrySetAsync(cacheKey, cacheValue, expiration);
+                flag = await _distributedCache.TrySetAsync(cacheKey, cacheValue, expiration, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -461,19 +468,19 @@
             {
                 // When we TrySet succeed in distributed cache, we should Set this cache to local cache.
                 // It's mainly to prevent the cache value was changed
-                await _localCache.SetAsync(cacheKey, cacheValue, expiration);
+                await _localCache.SetAsync(cacheKey, cacheValue, expiration, cancellationToken);
             }
 
             // distributed cache occur error, have a try with local cache
             if (distributedError)
             {
-                flag = await _localCache.TrySetAsync(cacheKey, cacheValue, expiration);
+                flag = await _localCache.TrySetAsync(cacheKey, cacheValue, expiration, cancellationToken);
             }
 
             if (flag)
             {
                 // Here should send message to bus due to cache was set successfully.
-                await _busAsyncWrap.ExecuteAsync(async () => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = new string[] { cacheKey } }));
+                await _busAsyncWrap.ExecuteAsync(async (ct) => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = new string[] { cacheKey } }, ct), cancellationToken);
             }
 
             return flag;
@@ -508,14 +515,15 @@
         /// <returns>The all async.</returns>
         /// <param name="value">Value.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public async Task SetAllAsync<T>(IDictionary<string, T> value, TimeSpan expiration)
+        public async Task SetAllAsync<T>(IDictionary<string, T> value, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
-            await _localCache.SetAllAsync(value, expiration);
+            await _localCache.SetAllAsync(value, expiration, cancellationToken);
 
             try
             {
-                await _distributedCache.SetAllAsync(value, expiration);
+                await _distributedCache.SetAllAsync(value, expiration, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -523,7 +531,7 @@
             }
 
             // send message to bus 
-            await _busAsyncWrap.ExecuteAsync(async () => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = value.Keys.ToArray(), IsPrefix = false }));
+            await _busAsyncWrap.ExecuteAsync(async (ct) => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = value.Keys.ToArray(), IsPrefix = false }, ct), cancellationToken);
         }
 
         /// <summary>
@@ -554,23 +562,24 @@
         /// </summary>
         /// <returns>The all async.</returns>
         /// <param name="cacheKeys">Cache keys.</param>
-        public async Task RemoveAllAsync(IEnumerable<string> cacheKeys)
+        /// <param name="cancellationToken">CancellationToken</param>
+        public async Task RemoveAllAsync(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullAndCountGTZero(cacheKeys, nameof(cacheKeys));
 
             try
             {
-                await _distributedCache.RemoveAllAsync(cacheKeys);
+                await _distributedCache.RemoveAllAsync(cacheKeys, cancellationToken);
             }
             catch (Exception ex)
             {
                 LogMessage($"remove all async from distributed provider error [{string.Join(",", cacheKeys)}]", ex);
             }
 
-            await _localCache.RemoveAllAsync(cacheKeys);
+            await _localCache.RemoveAllAsync(cacheKeys, cancellationToken);
 
             // send message to bus in order to notify other clients.
-            await _busAsyncWrap.ExecuteAsync(async () => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = cacheKeys.ToArray() }));
+            await _busAsyncWrap.ExecuteAsync(async (ct) => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = cacheKeys.ToArray() }, ct), cancellationToken);
         }
 
         /// <summary>
@@ -621,13 +630,14 @@
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="dataRetriever">Data retriever.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public async Task<CacheValue<T>> GetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration)
+        public async Task<CacheValue<T>> GetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNegativeOrZero(expiration, nameof(expiration));
 
-            var result = await _localCache.GetAsync<T>(cacheKey);
+            var result = await _localCache.GetAsync<T>(cacheKey, cancellationToken);
 
             if (result.HasValue)
             {
@@ -636,7 +646,7 @@
 
             try
             {
-                result = await _distributedCache.GetAsync<T>(cacheKey, dataRetriever, expiration);
+                result = await _distributedCache.GetAsync<T>(cacheKey, dataRetriever, expiration, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -645,7 +655,7 @@
 
             if (result.HasValue)
             {
-                TimeSpan ts = await GetExpirationAsync(cacheKey);
+                TimeSpan ts = await GetExpirationAsync(cacheKey, cancellationToken);
 
                 _localCache.Set(cacheKey, result.Value, ts);
 
@@ -683,13 +693,14 @@
         /// </summary>
         /// <returns>The by prefix async.</returns>
         /// <param name="prefix">Prefix.</param>
-        public async Task RemoveByPrefixAsync(string prefix)
+        /// <param name="cancellationToken">CancellationToken</param>
+        public async Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(prefix, nameof(prefix));
 
             try
             {
-                await _distributedCache.RemoveByPrefixAsync(prefix);
+                await _distributedCache.RemoveByPrefixAsync(prefix, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -699,7 +710,7 @@
             await _localCache.RemoveByPrefixAsync(prefix);
 
             // send message to bus in order to notify other clients.
-            await _busAsyncWrap.ExecuteAsync(async () => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = new string[] { prefix }, IsPrefix = true }));
+            await _busAsyncWrap.ExecuteAsync(async (ct) => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = new string[] { prefix }, IsPrefix = true }, ct), cancellationToken);
         }
 
         /// <summary>
@@ -722,13 +733,13 @@
             }
         }
 
-        private async Task<TimeSpan> GetExpirationAsync(string cacheKey)
+        private async Task<TimeSpan> GetExpirationAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             TimeSpan ts = TimeSpan.Zero;
 
             try
             {
-                ts = await _distributedCache.GetExpirationAsync(cacheKey);
+                ts = await _distributedCache.GetExpirationAsync(cacheKey, cancellationToken);
             }
             catch
             {
@@ -764,11 +775,11 @@
             return ts;
         }
 
-        public async Task<object> GetAsync(string cacheKey, Type type)
+        public async Task<object> GetAsync(string cacheKey, Type type, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
-            var cacheValue = await _localCache.GetAsync(cacheKey, type);
+            var cacheValue = await _localCache.GetAsync(cacheKey, type, cancellationToken);
 
             if (cacheValue != null)
             {
@@ -779,7 +790,7 @@
 
             try
             {
-                cacheValue = await _distributedCache.GetAsync(cacheKey, type);
+                cacheValue = await _distributedCache.GetAsync(cacheKey, type, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -788,9 +799,9 @@
 
             if (cacheValue != null)
             {
-                TimeSpan ts = await GetExpirationAsync(cacheKey);
+                TimeSpan ts = await GetExpirationAsync(cacheKey, cancellationToken);
               
-                await _localCache.SetAsync(cacheKey, cacheValue, ts);
+                await _localCache.SetAsync(cacheKey, cacheValue, ts, cancellationToken);
 
                 return cacheValue;
             }

--- a/src/EasyCaching.LiteDB/DefaultLiteDBCachingProvider.Async.cs
+++ b/src/EasyCaching.LiteDB/DefaultLiteDBCachingProvider.Async.cs
@@ -4,6 +4,7 @@
     using Microsoft.Extensions.Logging;
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -16,11 +17,12 @@
         /// </summary>
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
-        public override async Task<bool> BaseExistsAsync(string cacheKey)
+        /// <param name="cancellationToken">CancellationToken</param>
+        public override async Task<bool> BaseExistsAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
-            return await Task.Run(() => BaseExists(cacheKey));
+            return await Task.Run(() => BaseExists(cacheKey), cancellationToken);
         }
 
         /// <summary>
@@ -30,8 +32,9 @@
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="dataRetriever">Data retriever.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public override async Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration)
+        public override async Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNegativeOrZero(expiration, nameof(expiration));
@@ -41,7 +44,7 @@
                                 {
                                     return dataRetriever.Invoke().GetAwaiter().GetResult();
                                 }, expiration);
-                        });
+                        }, cancellationToken);
         }
 
         /// <summary>
@@ -49,11 +52,12 @@
         /// </summary>
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public override async Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey)
+        public override async Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
-            return await Task.Run(() => BaseGet<T>(cacheKey));
+            return await Task.Run(() => BaseGet<T>(cacheKey), cancellationToken);
         }
 
         /// <summary>
@@ -61,9 +65,10 @@
         /// </summary>
         /// <returns>The count.</returns>
         /// <param name="prefix">Prefix.</param>
-        public override async Task<int> BaseGetCountAsync(string prefix = "")
+        /// <param name="cancellationToken">CancellationToken</param>
+        public override async Task<int> BaseGetCountAsync(string prefix = "", CancellationToken cancellationToken = default)
         {
-            return await Task.Run(() => BaseGetCount(prefix));
+            return await Task.Run(() => BaseGetCount(prefix), cancellationToken);
         }
 
         /// <summary>
@@ -72,10 +77,11 @@
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="type">Object Type.</param>
-        public override async Task<object> BaseGetAsync(string cacheKey, Type type)
+        /// <param name="cancellationToken">CancellationToken</param>
+        public override async Task<object> BaseGetAsync(string cacheKey, Type type, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
-            return await Task.Run(() => System.Convert.ChangeType(BaseGet<object>(cacheKey).Value, type));
+            return await Task.Run(() => System.Convert.ChangeType(BaseGet<object>(cacheKey).Value, type), cancellationToken);
         }
 
         /// <summary>
@@ -83,11 +89,12 @@
         /// </summary>
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
-        public override async Task BaseRemoveAsync(string cacheKey)
+        /// <param name="cancellationToken">CancellationToken</param>
+        public override async Task BaseRemoveAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
-            await Task.Run(() => BaseRemove(cacheKey));
+            await Task.Run(() => BaseRemove(cacheKey), cancellationToken);
         }
 
         /// <summary>
@@ -97,27 +104,29 @@
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="cacheValue">Cache value.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public override async Task BaseSetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public override async Task BaseSetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNull(cacheValue, nameof(cacheValue), _options.CacheNulls);
             ArgumentCheck.NotNegativeOrZero(expiration, nameof(expiration));
-            await Task.Run(() => BaseSet<T>(cacheKey, cacheValue, expiration));
+            await Task.Run(() => BaseSet<T>(cacheKey, cacheValue, expiration), cancellationToken);
         }
 
         /// <summary>
         /// Removes cached item by cachekey's prefix async.
         /// </summary>
         /// <param name="prefix">Prefix of CacheKey.</param>
-        public override async Task BaseRemoveByPrefixAsync(string prefix)
+        /// <param name="cancellationToken">CancellationToken</param>
+        public override async Task BaseRemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(prefix, nameof(prefix));
 
             if (_options.EnableLogging)
                 _logger?.LogInformation($"RemoveByPrefixAsync : prefix = {prefix}");
 
-            await Task.Run(() => BaseRemoveByPrefix(prefix));
+            await Task.Run(() => BaseRemoveByPrefix(prefix), cancellationToken);
         }
 
         /// <summary>
@@ -126,10 +135,11 @@
         /// <returns>The all async.</returns>
         /// <param name="values">Values.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public override async Task BaseSetAllAsync<T>(IDictionary<string, T> values, TimeSpan expiration)
+        public override async Task BaseSetAllAsync<T>(IDictionary<string, T> values, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
-            await Task.Run(() => BaseSetAll(values, expiration));
+            await Task.Run(() => BaseSetAll(values, expiration), cancellationToken);
         }
 
         /// <summary>
@@ -137,11 +147,12 @@
         /// </summary>
         /// <returns>The all async.</returns>
         /// <param name="cacheKeys">Cache keys.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public override async Task<IDictionary<string, CacheValue<T>>> BaseGetAllAsync<T>(IEnumerable<string> cacheKeys)
+        public override async Task<IDictionary<string, CacheValue<T>>> BaseGetAllAsync<T>(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullAndCountGTZero(cacheKeys, nameof(cacheKeys));
-            return await Task.Run(() => BaseGetAll<T>(cacheKeys));
+            return await Task.Run(() => BaseGetAll<T>(cacheKeys), cancellationToken);
         }
 
         /// <summary>
@@ -149,12 +160,13 @@
         /// </summary>
         /// <returns>The by prefix async.</returns>
         /// <param name="prefix">Prefix.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public override async Task<IDictionary<string, CacheValue<T>>> BaseGetByPrefixAsync<T>(string prefix)
+        public override async Task<IDictionary<string, CacheValue<T>>> BaseGetByPrefixAsync<T>(string prefix, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(prefix, nameof(prefix));
 
-            return await Task.Run(() => BaseGetByPrefix<T>(prefix));
+            return await Task.Run(() => BaseGetByPrefix<T>(prefix), cancellationToken);
         }
 
         /// <summary>
@@ -162,17 +174,19 @@
         /// </summary>
         /// <returns>The all async.</returns>
         /// <param name="cacheKeys">Cache keys.</param>
-        public override async Task BaseRemoveAllAsync(IEnumerable<string> cacheKeys)
+        /// <param name="cancellationToken">CancellationToken</param>
+        public override async Task BaseRemoveAllAsync(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullAndCountGTZero(cacheKeys, nameof(cacheKeys));
-            await Task.Run(() => BaseRemoveAll(cacheKeys));
+            await Task.Run(() => BaseRemoveAll(cacheKeys), cancellationToken);
         }
 
         /// <summary>
         /// Flush All Cached Item async.
         /// </summary>
         /// <returns>The async.</returns>
-        public override async Task BaseFlushAsync() => await Task.Run(BaseFlush);
+        /// <param name="cancellationToken">CancellationToken</param>
+        public override async Task BaseFlushAsync(CancellationToken cancellationToken = default) => await Task.Run(BaseFlush, cancellationToken);
 
         /// <summary>
         /// Tries the set async.
@@ -181,24 +195,26 @@
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="cacheValue">Cache value.</param>
         /// <param name="expiration">Expiration.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public override async Task<bool> BaseTrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public override async Task<bool> BaseTrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
             ArgumentCheck.NotNull(cacheValue, nameof(cacheValue), _options.CacheNulls);
             ArgumentCheck.NotNegativeOrZero(expiration, nameof(expiration));
-            return await Task.Run(() => BaseTrySet(cacheKey, cacheValue, expiration));
+            return await Task.Run(() => BaseTrySet(cacheKey, cacheValue, expiration), cancellationToken);
         }
 
         /// <summary>
         /// Get the expiration of cache key async
         /// </summary>
         /// <param name="cacheKey">cache key</param>
+        /// <param name="cancellationToken">CancellationToken</param>
         /// <returns>expiration</returns>
-        public override async Task<TimeSpan> BaseGetExpirationAsync(string cacheKey)
+        public override async Task<TimeSpan> BaseGetExpirationAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
-            return await Task.Run(() => BaseGetExpiration(cacheKey));
+            return await Task.Run(() => BaseGetExpiration(cacheKey), cancellationToken);
         }
     }
 }

--- a/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
@@ -185,7 +185,7 @@
         [Fact]
         public async Task Distributed_Remove_Async_Throw_Exception_Should_Not_Break()
         {
-            A.CallTo(() => fakeDisProvider.RemoveAsync("fake-remove-key")).ThrowsAsync(new Exception());
+            A.CallTo(() => fakeDisProvider.RemoveAsync("fake-remove-key", default)).ThrowsAsync(new Exception());
 
             await fakeHybrid.RemoveAsync("fake-remove-key");
 
@@ -210,7 +210,7 @@
         [Fact]
         public async Task Distributed_Set_Async_Throw_Exception_Should_Not_Break()
         {
-            A.CallTo(() => fakeDisProvider.SetAsync(A<string>.Ignored, A<string>.Ignored, A<TimeSpan>.Ignored)).ThrowsAsync(new Exception());
+            A.CallTo(() => fakeDisProvider.SetAsync(A<string>.Ignored, A<string>.Ignored, A<TimeSpan>.Ignored, default)).ThrowsAsync(new Exception());
 
             var key = $"d-set-{Guid.NewGuid().ToString()}";
 

--- a/test/EasyCaching.UnitTests/Diagnostics/MyCachingProvider.cs
+++ b/test/EasyCaching.UnitTests/Diagnostics/MyCachingProvider.cs
@@ -3,6 +3,7 @@
     using EasyCaching.Core;
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
 
     public class MyCachingProvider : EasyCachingAbstractProvider
@@ -21,7 +22,7 @@
             return true;
         }
 
-        public override Task<bool> BaseExistsAsync(string cacheKey)
+        public override Task<bool> BaseExistsAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(false);
         }
@@ -31,7 +32,7 @@
 
         }
 
-        public override Task BaseFlushAsync()
+        public override Task BaseFlushAsync(CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -51,22 +52,22 @@
             return null;
         }
 
-        public override Task<IDictionary<string, CacheValue<T>>> BaseGetAllAsync<T>(IEnumerable<string> cacheKeys)
+        public override Task<IDictionary<string, CacheValue<T>>> BaseGetAllAsync<T>(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
             return null;
         }
 
-        public override Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration)
+        public override Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(CacheValue<T>.NoValue);
         }
 
-        public override Task<object> BaseGetAsync(string cacheKey, Type type)
+        public override Task<object> BaseGetAsync(string cacheKey, Type type, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<object>(null);
         }
 
-        public override Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey)
+        public override Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(CacheValue<T>.NoValue);
         }
@@ -76,7 +77,7 @@
             return null;
         }
 
-        public override Task<IDictionary<string, CacheValue<T>>> BaseGetByPrefixAsync<T>(string prefix)
+        public override Task<IDictionary<string, CacheValue<T>>> BaseGetByPrefixAsync<T>(string prefix, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<IDictionary<string, CacheValue<T>>>(null);
         }
@@ -86,7 +87,7 @@
             return 1;
         }
 
-        public override Task<int> BaseGetCountAsync(string prefix = "")
+        public override Task<int> BaseGetCountAsync(string prefix = "", CancellationToken cancellationToken = default)
         {
             return Task.FromResult(1);
         }
@@ -96,7 +97,7 @@
             return TimeSpan.FromSeconds(1);
         }
 
-        public override Task<TimeSpan> BaseGetExpirationAsync(string cacheKey)
+        public override Task<TimeSpan> BaseGetExpirationAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(TimeSpan.FromSeconds(1));
         }
@@ -116,12 +117,12 @@
 
         }
 
-        public override Task BaseRemoveAllAsync(IEnumerable<string> cacheKeys)
+        public override Task BaseRemoveAllAsync(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
 
-        public override Task BaseRemoveAsync(string cacheKey)
+        public override Task BaseRemoveAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -131,7 +132,7 @@
 
         }
 
-        public override Task BaseRemoveByPrefixAsync(string prefix)
+        public override Task BaseRemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -146,12 +147,12 @@
 
         }
 
-        public override Task BaseSetAllAsync<T>(IDictionary<string, T> values, TimeSpan expiration)
+        public override Task BaseSetAllAsync<T>(IDictionary<string, T> values, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
 
-        public override Task BaseSetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public override Task BaseSetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -161,7 +162,7 @@
             return false;
         }
 
-        public override Task<bool> BaseTrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public override Task<bool> BaseTrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(false);
         }

--- a/test/EasyCaching.UnitTests/DistributedLock/EasyCachingAbstractProviderTest.cs
+++ b/test/EasyCaching.UnitTests/DistributedLock/EasyCachingAbstractProviderTest.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -55,7 +56,7 @@ namespace EasyCaching.UnitTests.DistributedLock
             throw new InvalidOperationException();
         }
 
-        public override Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration)
+        public override Task<CacheValue<T>> BaseGetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             throw new InvalidOperationException();
         }

--- a/test/EasyCaching.UnitTests/Fake/FakeDistributedCachingProvider.cs
+++ b/test/EasyCaching.UnitTests/Fake/FakeDistributedCachingProvider.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using EasyCaching.Core;
 
@@ -28,7 +29,7 @@
             return true;
         }
 
-        public virtual Task<bool> ExistsAsync(string cacheKey)
+        public virtual Task<bool> ExistsAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(true);
         }
@@ -38,7 +39,7 @@
 
         }
 
-        public virtual Task FlushAsync()
+        public virtual Task FlushAsync(CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -58,23 +59,23 @@
             return new Dictionary<string, CacheValue<T>>();
         }
 
-        public virtual Task<IDictionary<string, CacheValue<T>>> GetAllAsync<T>(IEnumerable<string> cacheKeys)
+        public virtual Task<IDictionary<string, CacheValue<T>>> GetAllAsync<T>(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
             IDictionary<string, CacheValue<T>> dict = new Dictionary<string, CacheValue<T>>();
             return Task.FromResult(dict);
         }
 
-        public virtual Task<CacheValue<T>> GetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration)
+        public virtual Task<CacheValue<T>> GetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new CacheValue<T>(default(T), true));
         }
 
-        public virtual Task<object> GetAsync(string cacheKey, Type type)
+        public virtual Task<object> GetAsync(string cacheKey, Type type, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<object>(null);
         }
 
-        public virtual Task<CacheValue<T>> GetAsync<T>(string cacheKey)
+        public virtual Task<CacheValue<T>> GetAsync<T>(string cacheKey, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new CacheValue<T>(default(T), true));
         }
@@ -84,7 +85,7 @@
             return new Dictionary<string, CacheValue<T>>();
         }
 
-        public virtual Task<IDictionary<string, CacheValue<T>>> GetByPrefixAsync<T>(string prefix)
+        public virtual Task<IDictionary<string, CacheValue<T>>> GetByPrefixAsync<T>(string prefix, CancellationToken cancellationToken = default)
         {
             IDictionary<string, CacheValue<T>> dict = new Dictionary<string, CacheValue<T>>();
             return Task.FromResult(dict);
@@ -95,7 +96,7 @@
             return 1;
         }
 
-        public Task<int> GetCountAsync(string prefix = "")
+        public Task<int> GetCountAsync(string prefix = "", CancellationToken cancellationToken = default)
         {
             return Task.FromResult(1);
         }
@@ -105,7 +106,7 @@
             return TimeSpan.FromSeconds(1);
         }
 
-        public virtual Task<TimeSpan> GetExpirationAsync(string cacheKey)
+        public virtual Task<TimeSpan> GetExpirationAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(TimeSpan.FromSeconds(1));
         }
@@ -120,7 +121,7 @@
 
         }
 
-        public virtual Task RefreshAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public virtual Task RefreshAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -135,12 +136,12 @@
 
         }
 
-        public virtual Task RemoveAllAsync(IEnumerable<string> cacheKeys)
+        public virtual Task RemoveAllAsync(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
 
-        public virtual Task RemoveAsync(string cacheKey)
+        public virtual Task RemoveAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -150,7 +151,7 @@
 
         }
 
-        public virtual Task RemoveByPrefixAsync(string prefix)
+        public virtual Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -165,12 +166,12 @@
 
         }
 
-        public virtual Task SetAllAsync<T>(IDictionary<string, T> value, TimeSpan expiration)
+        public virtual Task SetAllAsync<T>(IDictionary<string, T> value, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
 
-        public virtual Task SetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public virtual Task SetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -180,7 +181,7 @@
             return true;
         }
 
-        public virtual Task<bool> TrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public virtual Task<bool> TrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(true);
         }

--- a/test/EasyCaching.UnitTests/Fake/FakeLocalCachingProvider.cs
+++ b/test/EasyCaching.UnitTests/Fake/FakeLocalCachingProvider.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using EasyCaching.Core;
 
@@ -28,7 +29,7 @@
             return true;
         }
 
-        public Task<bool> ExistsAsync(string cacheKey)
+        public Task<bool> ExistsAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(true);
         }
@@ -38,7 +39,7 @@
 
         }
 
-        public Task FlushAsync()
+        public Task FlushAsync(CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -58,23 +59,23 @@
             return new Dictionary<string, CacheValue<T>>();
         }
 
-        public Task<IDictionary<string, CacheValue<T>>> GetAllAsync<T>(IEnumerable<string> cacheKeys)
+        public Task<IDictionary<string, CacheValue<T>>> GetAllAsync<T>(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
             IDictionary<string, CacheValue<T>> dict = new Dictionary<string, CacheValue<T>>();
             return Task.FromResult(dict);
         }
 
-        public Task<CacheValue<T>> GetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration)
+        public Task<CacheValue<T>> GetAsync<T>(string cacheKey, Func<Task<T>> dataRetriever, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new CacheValue<T>(default(T), true));
         }
 
-        public Task<object> GetAsync(string cacheKey, Type type)
+        public Task<object> GetAsync(string cacheKey, Type type, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<object>(null);
         }
 
-        public Task<CacheValue<T>> GetAsync<T>(string cacheKey)
+        public Task<CacheValue<T>> GetAsync<T>(string cacheKey, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new CacheValue<T>(default(T), true));
         }
@@ -84,7 +85,7 @@
             return new Dictionary<string, CacheValue<T>>();
         }
 
-        public Task<IDictionary<string, CacheValue<T>>> GetByPrefixAsync<T>(string prefix)
+        public Task<IDictionary<string, CacheValue<T>>> GetByPrefixAsync<T>(string prefix, CancellationToken cancellationToken = default)
         {
             IDictionary<string, CacheValue<T>> dict = new Dictionary<string, CacheValue<T>>();
             return Task.FromResult(dict);
@@ -95,7 +96,7 @@
             return 1;
         }
 
-        public Task<int> GetCountAsync(string prefix = "")
+        public Task<int> GetCountAsync(string prefix = "", CancellationToken cancellationToken = default)
         {
             return Task.FromResult(1);
         }
@@ -105,7 +106,7 @@
             return TimeSpan.FromSeconds(1);
         }
 
-        public Task<TimeSpan> GetExpirationAsync(string cacheKey)
+        public Task<TimeSpan> GetExpirationAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(TimeSpan.FromSeconds(1));
         }
@@ -120,7 +121,7 @@
 
         }
 
-        public Task RefreshAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public Task RefreshAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -135,12 +136,12 @@
 
         }
 
-        public Task RemoveAllAsync(IEnumerable<string> cacheKeys)
+        public Task RemoveAllAsync(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
 
-        public Task RemoveAsync(string cacheKey)
+        public Task RemoveAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -150,7 +151,7 @@
 
         }
 
-        public Task RemoveByPrefixAsync(string prefix)
+        public Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -165,12 +166,12 @@
 
         }
 
-        public Task SetAllAsync<T>(IDictionary<string, T> value, TimeSpan expiration)
+        public Task SetAllAsync<T>(IDictionary<string, T> value, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
 
-        public Task SetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public Task SetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -180,7 +181,7 @@
             return true;
         }
 
-        public Task<bool> TrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration)
+        public Task<bool> TrySetAsync<T>(string cacheKey, T cacheValue, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(true);
         }


### PR DESCRIPTION
Hello

For a project of mine I needed a cache.
This library does everything I need and more.

I want to use the async functions.
There was missing for me the optional CancellationToken.
This is always quite handy.

I noticed during the implementation that not all providers support this.

Nevertheless, I added it everywhere in the function header and where the provider supported it also passed it.

I hope this "fix" or whatever comes in the next version.

Thanks a lot!