### PR TITLE
add `persist` key method to redis providers

### DIFF
--- a/src/EasyCaching.CSRedis/DefaultCSRedisCachingProvider.Keys.cs
+++ b/src/EasyCaching.CSRedis/DefaultCSRedisCachingProvider.Keys.cs
@@ -39,6 +39,22 @@
             var flag = await _cache.ExpireAsync(cacheKey, second);
             return flag;
         }
+        
+        public bool KeyPersist(string cacheKey)
+        {
+            ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
+            
+            var flag = _cache.Persist(cacheKey);
+            return flag;
+        }
+
+        public async Task<bool> KeyPersistAsync(string cacheKey)
+        {
+            ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
+            
+            var flag = await _cache.PersistAsync(cacheKey);
+            return flag;
+        }
 
         public bool KeyExists(string cacheKey)
         {

--- a/src/EasyCaching.Core/IRedisCachingProvider.cs
+++ b/src/EasyCaching.Core/IRedisCachingProvider.cs
@@ -42,6 +42,18 @@
         /// <returns></returns>
         Task<bool> KeyExpireAsync(string cacheKey, int second);
         /// <summary>
+        /// https://redis.io/commands/persist
+        /// </summary>
+        /// <param name="cacheKey"></param>
+        /// <returns></returns>
+        bool KeyPersist(string cacheKey);
+        /// <summary>
+        /// https://redis.io/commands/persist
+        /// </summary>
+        /// <param name="cacheKey"></param>
+        /// <returns></returns>
+        Task<bool> KeyPersistAsync(string cacheKey);
+        /// <summary>
         /// 
         /// </summary>
         /// <returns></returns>

--- a/src/EasyCaching.Redis/DefaultRedisCachingProvider.Keys.cs
+++ b/src/EasyCaching.Redis/DefaultRedisCachingProvider.Keys.cs
@@ -45,6 +45,22 @@
             var flag = await _cache.KeyExpireAsync(cacheKey, TimeSpan.FromSeconds(second));
             return flag;
         }
+        
+        public bool KeyPersist(string cacheKey)
+        {
+            ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
+
+            var flag = _cache.KeyPersist(cacheKey);
+            return flag;
+        }
+
+        public async Task<bool> KeyPersistAsync(string cacheKey)
+        {
+            ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
+
+            var flag = await _cache.KeyPersistAsync(cacheKey);
+            return flag;
+        }
 
         public bool KeyExists(string cacheKey)
         {

--- a/test/EasyCaching.UnitTests/CachingTests/BaseRedisFeatureCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/BaseRedisFeatureCachingProviderTest.cs
@@ -81,6 +81,30 @@
 
             await _provider.KeyDelAsync(cacheKey);
         }
+        
+        [Fact]
+        protected virtual async Task StringSetWithExpiration_And_Persist_And_TTL_Async_Should_Succeed()
+        {
+            var cacheKey = $"{_nameSpace}-{Guid.NewGuid().ToString()}";
+
+            var res = await _provider.StringSetAsync(cacheKey, "123", TimeSpan.FromSeconds(10));
+
+            Assert.True(res);
+            
+            var initialTtl = await _provider.TTLAsync(cacheKey);
+
+            Assert.InRange(initialTtl, 1, 10);
+
+            var flag = await _provider.KeyPersistAsync(cacheKey);
+
+            Assert.True(flag);
+
+            var persistedTtl = await _provider.TTLAsync(cacheKey);
+
+            Assert.Equal(persistedTtl, -1);
+
+            await _provider.KeyDelAsync(cacheKey);
+        }
         #endregion
 
         #region String


### PR DESCRIPTION
Added "[Persist](https://redis.io/commands/persist/)" operation in Redis providers + related test.