### PR TITLE
Fix: Update EnyimMemcachedCore to 2.5.4

### DIFF
--- a/src/EasyCaching.Memcached/Configurations/EasyCachingMemcachedClientConfiguration.cs
+++ b/src/EasyCaching.Memcached/Configurations/EasyCachingMemcachedClientConfiguration.cs
@@ -38,6 +38,7 @@
             var options = optionsAccessor.DBConfig;
 
             ConfigureServers(options);
+            UseSslStream = options.UseSslStream;
 
             SocketPool = new SocketPoolConfiguration();
             if (options.SocketPool != null)
@@ -181,6 +182,11 @@
         /// Gets the authentication settings.
         /// </summary>
         public IAuthenticationConfiguration Authentication { get; private set; }
+
+        /// <summary>
+        /// Gets the SSL Stream support.
+        /// </summary>
+        public bool UseSslStream { get; private set; }
 
         /// <summary>
         /// Gets or sets the <see cref="T:Enyim.Caching.Memcached.IMemcachedKeyTransformer"/> which will be used to convert item keys for Memcached.

--- a/src/EasyCaching.Memcached/EasyCaching.Memcached.csproj
+++ b/src/EasyCaching.Memcached/EasyCaching.Memcached.csproj
@@ -35,6 +35,6 @@
 		<ProjectReference Include="..\EasyCaching.Core\EasyCaching.Core.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="EnyimMemcachedCore" Version="2.5.3" />
+		<PackageReference Include="EnyimMemcachedCore" Version="2.5.4" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Update EnyimMemcachedCore to 2.5.4

Issue:
Using EnyimMemcachedCore v2.5.4 along with EasyCaching.Memcached v1.6.1 in a project fails.

In assembly: EasyCaching.Memcached, Version=1.6.1.0,

the class [EasyCachingMemcachedClientConfiguration ](https://github.com/jainnipun/EasyCaching/blob/Fix-Swagger-generation-issue/src/EasyCaching.Memcached/Configurations/EasyCachingMemcachedClientConfiguration.cs)extends [IMemcachedClientConfiguration](https://github.com/cnblogs/EnyimMemcachedCore/blob/master/Enyim.Caching/Configuration/IMemcachedClientConfiguration.cs)

IMemcachedClientConfiguration is present in Assembly: EnyimMemcachedCore, 

The assembly EnyimMemcachedCore was updated to have a bool variable UseSslStream on April 7 2022 (v 2.5.4).

But the assembly EasyCaching.Memcached still uses v 2.5.3 of EnyimMemcachedCore internally. ([csproj link](https://github.com/jainnipun/EasyCaching/blob/Fix-Swagger-generation-issue/src/EasyCaching.Memcached/EasyCaching.Memcached.csproj))

So if we try to update the EnyimMemcachedCore  to latest version, it will clash.









