### PR TITLE
Added a HybridCachingOption to throw an error if the distributed cache throws an error

### DIFF
--- a/src/EasyCaching.HybridCache/Configurations/HybridCachingOptions.cs
+++ b/src/EasyCaching.HybridCache/Configurations/HybridCachingOptions.cs
@@ -16,6 +16,12 @@
         public bool EnableLogging { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether an exception should be thrown if an error on the distributed cache has occurred
+        /// </summary>
+        /// <value><c>true</c> if distributed cache exceptions should not be ignored; otherwise, <c>false</c>.</value>
+        public bool ThrowIfDistributedCacheError { get; set; }
+
+        /// <summary>
         /// local cache provider name
         /// </summary>
         public string LocalCacheProviderName { get; set; }

--- a/src/EasyCaching.HybridCache/HybridCachingProvider.cs
+++ b/src/EasyCaching.HybridCache/HybridCachingProvider.cs
@@ -1,10 +1,5 @@
 ﻿namespace EasyCaching.HybridCache
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
-    using System.Threading.Tasks;
     using EasyCaching.Core;
     using EasyCaching.Core.Bus;
     using Microsoft.Extensions.Logging;
@@ -12,6 +7,11 @@
     using Polly.Fallback;
     using Polly.Retry;
     using Polly.Wrap;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Hybrid caching provider.
@@ -123,7 +123,7 @@
         /// <param name="message">Message.</param>
         private void OnMessage(EasyCachingMessage message)
         {
-            // each clients will recive the message, current client should ignore.
+            // each clients will receive the message, current client should ignore.
             if (!string.IsNullOrWhiteSpace(message.Id) && message.Id.Equals(_cacheId, StringComparison.OrdinalIgnoreCase))
                 return;
 
@@ -136,7 +136,7 @@
 
                 LogMessage($"remove local cache that pattern is {pattern}");
 
-                return;   
+                return;
             }
 
             // remove by prefix
@@ -178,6 +178,11 @@
             catch (Exception ex)
             {
                 LogMessage($"Check cache key exists error [{cacheKey}] ", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             flag = _localCache.Exists(cacheKey);
@@ -186,7 +191,7 @@
         }
 
         /// <summary>
-        /// Existses the specified cacheKey async.
+        /// Exists the specified cacheKey async.
         /// </summary>
         /// <returns>The async.</returns>
         /// <param name="cacheKey">Cache key.</param>
@@ -206,6 +211,11 @@
             catch (Exception ex)
             {
                 LogMessage($"Check cache key [{cacheKey}] exists error", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             flag = await _localCache.ExistsAsync(cacheKey, cancellationToken);
@@ -239,12 +249,17 @@
             catch (Exception ex)
             {
                 LogMessage($"distributed cache get error, [{cacheKey}]", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             if (cacheValue.HasValue)
             {
                 TimeSpan ts = GetExpiration(cacheKey);
-               
+
                 _localCache.Set(cacheKey, cacheValue.Value, ts);
 
                 return cacheValue;
@@ -282,6 +297,11 @@
             catch (Exception ex)
             {
                 LogMessage($"distributed cache get error, [{cacheKey}]", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             if (cacheValue.HasValue)
@@ -314,6 +334,11 @@
             catch (Exception ex)
             {
                 LogMessage($"remove cache key [{cacheKey}] error", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             _localCache.Remove(cacheKey);
@@ -340,6 +365,11 @@
             catch (Exception ex)
             {
                 LogMessage($"remove cache key [{cacheKey}] error", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             await _localCache.RemoveAsync(cacheKey, cancellationToken);
@@ -368,6 +398,11 @@
             catch (Exception ex)
             {
                 LogMessage($"set cache key [{cacheKey}] error", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             // When create/update cache, send message to bus so that other clients can remove it.
@@ -396,6 +431,11 @@
             catch (Exception ex)
             {
                 LogMessage($"set cache key [{cacheKey}] error", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             // When create/update cache, send message to bus so that other clients can remove it.
@@ -425,6 +465,11 @@
             {
                 distributedError = true;
                 LogMessage($"tryset cache key [{cacheKey}] error", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             if (flag && !distributedError)
@@ -473,6 +518,11 @@
             {
                 distributedError = true;
                 LogMessage($"tryset cache key [{cacheKey}] error", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             if (flag && !distributedError)
@@ -514,6 +564,11 @@
             catch (Exception ex)
             {
                 LogMessage($"set all from distributed provider error [{string.Join(",", value.Keys)}]", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             // send message to bus 
@@ -539,6 +594,11 @@
             catch (Exception ex)
             {
                 LogMessage($"set all from distributed provider error [{string.Join(",", value.Keys)}]", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             // send message to bus 
@@ -555,11 +615,16 @@
 
             try
             {
-                _distributedCache.RemoveAllAsync(cacheKeys);
+                _distributedCache.RemoveAll(cacheKeys);
             }
             catch (Exception ex)
             {
                 LogMessage($"remove all from distributed provider error [{string.Join(",", cacheKeys)}]", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             _localCache.RemoveAll(cacheKeys);
@@ -585,6 +650,11 @@
             catch (Exception ex)
             {
                 LogMessage($"remove all async from distributed provider error [{string.Join(",", cacheKeys)}]", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             await _localCache.RemoveAllAsync(cacheKeys, cancellationToken);
@@ -620,6 +690,11 @@
             catch (Exception ex)
             {
                 LogMessage($"get with data retriever from distributed provider error [{cacheKey}]", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             if (result.HasValue)
@@ -662,13 +737,18 @@
             catch (Exception ex)
             {
                 LogMessage($"get async with data retriever from distributed provider error [{cacheKey}]", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             if (result.HasValue)
             {
                 TimeSpan ts = await GetExpirationAsync(cacheKey, cancellationToken);
 
-                _localCache.Set(cacheKey, result.Value, ts);
+                await _localCache.SetAsync(cacheKey, result.Value, ts, cancellationToken);
 
                 return result;
             }
@@ -691,6 +771,11 @@
             catch (Exception ex)
             {
                 LogMessage($"remove by prefix [{prefix}] error", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             _localCache.RemoveByPrefix(prefix);
@@ -716,14 +801,19 @@
             catch (Exception ex)
             {
                 LogMessage($"remove by prefix [{prefix}] error", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
-            await _localCache.RemoveByPrefixAsync(prefix);
+            await _localCache.RemoveByPrefixAsync(prefix, cancellationToken);
 
             // send message to bus in order to notify other clients.
             await _busAsyncWrap.ExecuteAsync(async (ct) => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = new string[] { prefix }, IsPrefix = true }, ct), cancellationToken);
         }
-        
+
         /// <summary>
         /// Removes the by pattern async.
         /// </summary>
@@ -741,14 +831,19 @@
             catch (Exception ex)
             {
                 LogMessage($"remove by pattern [{pattern}] error", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
-            await _localCache.RemoveByPatternAsync(pattern);
+            await _localCache.RemoveByPatternAsync(pattern, cancellationToken);
 
             // send message to bus in order to notify other clients.
-            await _busAsyncWrap.ExecuteAsync(async (ct) => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = new string[] { pattern }, IsPattern = true}, ct), cancellationToken);
+            await _busAsyncWrap.ExecuteAsync(async (ct) => await _bus.PublishAsync(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = new string[] { pattern }, IsPattern = true }, ct), cancellationToken);
         }
-        
+
         /// <summary>
         /// Removes the by pattern.
         /// </summary>
@@ -765,12 +860,17 @@
             catch (Exception ex)
             {
                 LogMessage($"remove by pattern [{pattern}] error", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             _localCache.RemoveByPattern(pattern);
 
             // send message to bus 
-            _busSyncWrap.Execute(() => _bus.Publish(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = new string[] { pattern }, IsPattern = true}));
+            _busSyncWrap.Execute(() => _bus.Publish(_options.TopicName, new EasyCachingMessage { Id = _cacheId, CacheKeys = new string[] { pattern }, IsPattern = true }));
         }
 
         /// <summary>
@@ -855,12 +955,17 @@
             catch (Exception ex)
             {
                 LogMessage($"distributed cache get error, [{cacheKey}]", ex);
+
+                if (_options.ThrowIfDistributedCacheError)
+                {
+                    throw;
+                }
             }
 
             if (cacheValue != null)
             {
                 TimeSpan ts = await GetExpirationAsync(cacheKey, cancellationToken);
-              
+
                 await _localCache.SetAsync(cacheKey, cacheValue, ts, cancellationToken);
 
                 return cacheValue;

--- a/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/HybridCachingTest.cs
@@ -1,24 +1,20 @@
 ﻿namespace EasyCaching.UnitTests
 {
-    using EasyCaching.Bus.Redis;
     using EasyCaching.Core;
     using EasyCaching.Core.Bus;
     using EasyCaching.HybridCache;
-    using EasyCaching.InMemory;
-    using EasyCaching.Redis;
+    using FakeItEasy;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Options;
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Xunit;
-    using FakeItEasy;
-    using System.Threading;
 
     public class HybridCachingTest //: BaseCachingProviderTest
     {
-        private string _namespace;
+        private readonly string _namespace;
         private IHybridCachingProvider hybridCaching_1;
-        private IEasyCachingProviderFactory factory;
 
         private HybridCachingProvider fakeHybrid;
         private IEasyCachingProviderFactory fakeFactory;
@@ -32,6 +28,7 @@
             var options = new HybridCachingOptions
             {
                 EnableLogging = false,
+                ThrowIfDistributedCacheError = false,
                 TopicName = "test_topic",
                 LocalCacheProviderName = "m1",
                 DistributedCacheProviderName = "myredis",
@@ -54,6 +51,7 @@
                 option.UseHybrid(config =>
                 {
                     config.EnableLogging = false;
+                    config.ThrowIfDistributedCacheError = false;
                     config.TopicName = "test_topic";
                     config.LocalCacheProviderName = "m1";
                     config.DistributedCacheProviderName = "myredis";
@@ -68,7 +66,6 @@
             });
 
             IServiceProvider serviceProvider = services.BuildServiceProvider();
-            factory = serviceProvider.GetService<IEasyCachingProviderFactory>();
 
             var bus = serviceProvider.GetService<IEasyCachingBus>();
 
@@ -171,7 +168,7 @@
 
             Assert.True(true);
         }
-              
+
         [Fact]
         public void Distributed_Remove_Throw_Exception_Should_Not_Break()
         {


### PR DESCRIPTION
Added a HybridCachingOption to throw an error if the distributed cache throws an error. Added this functionality to be able to guarantee certain changes which might happen to the distributed cache. Wondering if its okay to have something like EnsureDistributedCacheUpdates to make sure the updates are actually sent. As it currently stands there is no easy way to guarantee any updates to the distributed cache are actually written. This will be an opt-in feature without breaking any existing functionality