### PR TITLE
add reconnect handler and flush in-memory on reconnect

### DIFF
--- a/bus/EasyCaching.Bus.RabbitMQ/DefaultRabbitMQBus.cs
+++ b/bus/EasyCaching.Bus.RabbitMQ/DefaultRabbitMQBus.cs
@@ -148,20 +148,28 @@
                 queueName = _options.QueueName;
             }
 
-            Task.Factory.StartNew(() =>
+            Task.Factory.StartNew(
+                () => StartConsumer(queueName, topic),
+                TaskCreationOptions.LongRunning);
+        }
+
+        private void StartConsumer(string queueName, string topic)
+        {
+            var model = _subConnection.CreateModel();
+            model.ExchangeDeclare(_options.TopicExchangeName, ExchangeType.Topic, true, false, null);
+            model.QueueDeclare(queueName, false, false, true, null);
+            // bind the queue with the exchange.
+            model.QueueBind(queueName, _options.TopicExchangeName, topic);
+            var consumer = new EventingBasicConsumer(model);
+            consumer.Received += OnMessage;
+            consumer.Shutdown += (sender, e) =>
             {
-                var model = _subConnection.CreateModel();
-                model.ExchangeDeclare(_options.TopicExchangeName, ExchangeType.Topic, true, false, null);
-                model.QueueDeclare(queueName, false, false, true, null);
-                // bind the queue with the exchange.
-                model.QueueBind(queueName, _options.TopicExchangeName, topic);
-                var consumer = new EventingBasicConsumer(model);
-                consumer.Received += OnMessage;
-                consumer.Shutdown += OnConsumerShutdown;
+                OnConsumerShutdown(sender, e);
+                StartConsumer(queueName, topic);
+                BaseOnReconnect();
+            };
 
-                model.BasicConsume(queueName, true, consumer);
-
-            }, TaskCreationOptions.LongRunning);
+            model.BasicConsume(queueName, true, consumer);
         }
 
         /// <summary>

--- a/src/EasyCaching.Core/Bus/IEasyCachingSubscriber.cs
+++ b/src/EasyCaching.Core/Bus/IEasyCachingSubscriber.cs
@@ -12,6 +12,7 @@
         /// </summary>
         /// <param name="topic">Topic.</param>
         /// <param name="action">Action.</param>
-        void Subscribe(string topic, Action<EasyCachingMessage> action);
+        /// <param name="reconnectAction"> Reconnect Action.</param>
+        void Subscribe(string topic, Action<EasyCachingMessage> action, Action reconnectAction = null);
     }
 }

--- a/src/EasyCaching.Core/Bus/NullEasyCachingBus.cs
+++ b/src/EasyCaching.Core/Bus/NullEasyCachingBus.cs
@@ -26,7 +26,7 @@
         /// <see cref="T:EasyCaching.Core.Bus.NullEasyCachingBus"/> so the garbage collector can reclaim the memory that
         /// the <see cref="T:EasyCaching.Core.Bus.NullEasyCachingBus"/> was occupying.</remarks>
         public void Dispose() { }
-               
+
         /// <summary>
         /// Publish the specified topic and message.
         /// </summary>
@@ -54,7 +54,8 @@
         /// </summary>
         /// <param name="topic">Topic.</param>
         /// <param name="action">Action.</param>
-        public void Subscribe(string topic, Action<EasyCachingMessage> action)
+        /// <param name="reconnectAction">Reconnect Action.</param>
+        public void Subscribe(string topic, Action<EasyCachingMessage> action, Action reconnectAction = null)
         {
 
         }

--- a/src/EasyCaching.Core/EasyCachingAbstractBus.cs
+++ b/src/EasyCaching.Core/EasyCachingAbstractBus.cs
@@ -1,11 +1,11 @@
 ﻿namespace EasyCaching.Core
 {
-    using EasyCaching.Core.Bus;
-    using EasyCaching.Core.Diagnostics;
     using System;
     using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
+    using EasyCaching.Core.Bus;
+    using EasyCaching.Core.Diagnostics;
 
     public abstract class EasyCachingAbstractBus : IEasyCachingBus
     {
@@ -18,8 +18,8 @@
 
         protected Action<EasyCachingMessage> _handler;
 
+        protected Action _reconnectHandler;
         protected string BusName { get; set; }
-
         public string Name => this.BusName;
 
         public void Publish(string topic, EasyCachingMessage message)
@@ -74,9 +74,10 @@
             }
         }
 
-        public void Subscribe(string topic, Action<EasyCachingMessage> action)
+        public void Subscribe(string topic, Action<EasyCachingMessage> action, Action reconnectAction = null)
         {
             _handler = action;
+            _reconnectHandler = reconnectAction;
             BaseSubscribe(topic, action);
         }
 
@@ -104,6 +105,11 @@
                     s_diagnosticListener.WritePublishMessageAfter(operationId);
                 }
             }
+        }
+
+        public virtual void BaseOnReconnect()
+        {
+            _reconnectHandler?.Invoke();
         }
     }
 }

--- a/src/EasyCaching.HybridCache/HybridCachingProvider.cs
+++ b/src/EasyCaching.HybridCache/HybridCachingProvider.cs
@@ -93,7 +93,7 @@
             else this._distributedCache = distributed;
 
             this._bus = bus ?? NullEasyCachingBus.Instance;
-            this._bus.Subscribe(_options.TopicName, OnMessage);
+            this._bus.Subscribe(_options.TopicName, OnMessage, OnReconnect);
 
             this._cacheId = Guid.NewGuid().ToString("N");
 
@@ -157,6 +157,12 @@
 
                 LogMessage($"remove local cache that cache key is {item}");
             }
+        }
+
+        private void OnReconnect()
+        {
+            LogMessage("Bus Reconnected, flushing in-memory keys");
+            _localCache.Flush();
         }
 
         /// <summary>

--- a/test/EasyCaching.UnitTests/Fake/FakeBus.cs
+++ b/test/EasyCaching.UnitTests/Fake/FakeBus.cs
@@ -19,7 +19,7 @@
             return Task.CompletedTask;
         }
 
-        public void Subscribe(string topic, Action<EasyCachingMessage> action)
+        public void Subscribe(string topic, Action<EasyCachingMessage> action, Action reconnectAction = null)
         {
 
         }


### PR DESCRIPTION
add a reconnect handler to perform the following tasks when reconnecting to rabbit
- re-create queue if missing
- flush local cache (could be stale)

When running RabbitMQ behind load balancers (which is a common practice on production systems) a load-balancer failure can trigger a disconnection during which the queue is dropped from rabbit.