### PR TITLE
feat: restore queue model and consumer on disconnection

### DIFF
--- a/src/EasyCaching.Core/Bus/IEasyCachingSubscriber.cs
+++ b/src/EasyCaching.Core/Bus/IEasyCachingSubscriber.cs
@@ -12,6 +12,7 @@
         /// </summary>
         /// <param name="topic">Topic.</param>
         /// <param name="action">Action.</param>
-        void Subscribe(string topic, Action<EasyCachingMessage> action);
+        /// <param name="reconnectAction"> Reconnect Action.</param>
+        void Subscribe(string topic, Action<EasyCachingMessage> action, Action reconnectAction = null);
     }
 }

--- a/src/EasyCaching.Core/Bus/NullEasyCachingBus.cs
+++ b/src/EasyCaching.Core/Bus/NullEasyCachingBus.cs
@@ -26,7 +26,7 @@
         /// <see cref="T:EasyCaching.Core.Bus.NullEasyCachingBus"/> so the garbage collector can reclaim the memory that
         /// the <see cref="T:EasyCaching.Core.Bus.NullEasyCachingBus"/> was occupying.</remarks>
         public void Dispose() { }
-               
+
         /// <summary>
         /// Publish the specified topic and message.
         /// </summary>
@@ -54,7 +54,8 @@
         /// </summary>
         /// <param name="topic">Topic.</param>
         /// <param name="action">Action.</param>
-        public void Subscribe(string topic, Action<EasyCachingMessage> action)
+        /// <param name="reconnectAction">Reconnect Action.</param>
+        public void Subscribe(string topic, Action<EasyCachingMessage> action, Action reconnectAction = null)
         {
 
         }

--- a/src/EasyCaching.Core/EasyCachingAbstractBus.cs
+++ b/src/EasyCaching.Core/EasyCachingAbstractBus.cs
@@ -18,6 +18,8 @@
 
         protected Action<EasyCachingMessage> _handler;
 
+        protected Action _reconnectHandler;
+        
         protected string BusName { get; set; }
 
         public string Name => this.BusName;
@@ -74,9 +76,10 @@
             }
         }
 
-        public void Subscribe(string topic, Action<EasyCachingMessage> action)
+        public void Subscribe(string topic, Action<EasyCachingMessage> action, Action reconnectAction)
         {
             _handler = action;
+            _reconnectHandler = reconnectAction;
             BaseSubscribe(topic, action);
         }
 
@@ -104,6 +107,11 @@
                     s_diagnosticListener.WritePublishMessageAfter(operationId);
                 }
             }
+        }
+
+        public virtual void BaseOnReconnect()
+        {
+            _reconnectHandler?.Invoke();
         }
     }
 }

--- a/src/EasyCaching.HybridCache/Configurations/HybridCachingOptions.cs
+++ b/src/EasyCaching.HybridCache/Configurations/HybridCachingOptions.cs
@@ -43,5 +43,13 @@
         /// When sending message failed, we will retry some times, default is 3 times.
         /// </remarks>
         public int BusRetryCount { get; set; } = 3;
+
+        /// <summary>
+        /// Flush the local cache on bus disconnection/reconnection
+        /// </summary>
+        /// <remarks>
+        /// Flushing the local cache will avoid using stale data but may cause app jitters until the local cache get's re-populated.
+        /// </remarks>
+        public bool FlushLocalCacheOnBusReconnection { get; set; } = false;
     }
 }

--- a/src/EasyCaching.HybridCache/HybridCachingProvider.cs
+++ b/src/EasyCaching.HybridCache/HybridCachingProvider.cs
@@ -93,7 +93,7 @@
             else this._distributedCache = distributed;
 
             this._bus = bus ?? NullEasyCachingBus.Instance;
-            this._bus.Subscribe(_options.TopicName, OnMessage);
+            this._bus.Subscribe(_options.TopicName, OnMessage, OnReconnect);
 
             this._cacheId = Guid.NewGuid().ToString("N");
 
@@ -157,6 +157,21 @@
 
                 LogMessage($"remove local cache that cache key is {item}");
             }
+        }
+
+        /// <summary>
+        /// On reconnect (flushes local memory as it could be stale).
+        /// </summary>
+
+        private void OnReconnect()
+        {
+            if (!_options.FlushLocalCacheOnBusReconnection)
+            {
+                return;
+            }
+
+            LogMessage("Flushing local cache due to bus reconnection");
+            _localCache.Flush();
         }
 
         /// <summary>

--- a/test/EasyCaching.UnitTests/Fake/FakeBus.cs
+++ b/test/EasyCaching.UnitTests/Fake/FakeBus.cs
@@ -19,7 +19,7 @@
             return Task.CompletedTask;
         }
 
-        public void Subscribe(string topic, Action<EasyCachingMessage> action)
+        public void Subscribe(string topic, Action<EasyCachingMessage> action, Action reconnectAction = null)
         {
 
         }


### PR DESCRIPTION
We have seen cases where a failure on the load balancers in front of our rabbit clusters triggers disconnections from the rabbit cluster and thus deletions of the ephemeral queues. This MR tries to solve this issue by recreating the model, the queue, and the binding and adding a consumer. The old model is then disposed. 