### PR TITLE
RedisCache configure code-only configuration for StackExchange.Redis

### DIFF
--- a/src/EasyCaching.Redis/Configurations/RedisDBOptions.cs
+++ b/src/EasyCaching.Redis/Configurations/RedisDBOptions.cs
@@ -1,6 +1,7 @@
 ﻿namespace EasyCaching.Redis
 {
     using EasyCaching.Core.Configurations;
+    using StackExchange.Redis;
 
     /// <summary>
     /// Redis cache options.
@@ -29,5 +30,10 @@
         /// Gets or sets the Redis database KeyPrefix will use.
         /// </summary>
         public string KeyPrefix { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Redis database ConfigurationOptions will use.
+        /// </summary>
+        public ConfigurationOptions ConfigurationOptions { get; set; }
     }
 }

--- a/src/EasyCaching.Redis/Configurations/RedisDatabaseProvider.cs
+++ b/src/EasyCaching.Redis/Configurations/RedisDatabaseProvider.cs
@@ -73,6 +73,9 @@
         /// <returns>The connection multiplexer.</returns>
         private ConnectionMultiplexer CreateConnectionMultiplexer()
         {
+            if (_options.ConfigurationOptions != null)
+                return ConnectionMultiplexer.Connect(_options.ConfigurationOptions.ToString());
+
             if (string.IsNullOrWhiteSpace(_options.Configuration))
             {
                 var configurationOptions = new ConfigurationOptions

--- a/test/EasyCaching.UnitTests/CachingTests/RedisCachingProviderTest.cs
+++ b/test/EasyCaching.UnitTests/CachingTests/RedisCachingProviderTest.cs
@@ -8,6 +8,7 @@ namespace EasyCaching.UnitTests
     using EasyCaching.Serialization.Json;
     using EasyCaching.Serialization.MessagePack;
     using Microsoft.Extensions.DependencyInjection;
+    using StackExchange.Redis;
     using System;
     using Xunit;
 
@@ -91,6 +92,24 @@ namespace EasyCaching.UnitTests
                 {
                     options.DBConfig.Configuration = "127.0.0.1:6380,allowAdmin=false,defaultdatabase=8";
                 }, ProviderName).WithJson(ProviderName));
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+            var dbProvider = serviceProvider.GetService<IRedisDatabaseProvider>();
+            Assert.NotNull(dbProvider);
+
+            Assert.Equal(8, dbProvider.GetDatabase().Database);
+        }
+
+        [Fact]
+        public void Use_Configuration_Options_Should_Succeed()
+        {
+            IServiceCollection services = new ServiceCollection();
+            var redisConfig = ConfigurationOptions.Parse("127.0.0.1:6380");
+            redisConfig.DefaultDatabase = 8;
+            services.AddEasyCaching(x =>
+                 x.UseRedis(options =>
+                 {
+                     options.DBConfig.ConfigurationOptions = redisConfig;
+                 }, ProviderName).UseRedisLock().WithJson(ProviderName));
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             var dbProvider = serviceProvider.GetService<IRedisDatabaseProvider>();
             Assert.NotNull(dbProvider);


### PR DESCRIPTION
### Content：
RedisCache support configure code-only configuration 

### Usage:
```C#
var redisConfig = ConfigurationOptions.Parse("127.0.0.1:6380");
redisConfig.DefaultDatabase = 8;
services.AddEasyCaching(x =>
     x.UseRedis(options =>
     {
         options.DBConfig.ConfigurationOptions = redisConfig;
     }, ProviderName).UseRedisLock().WithJson(ProviderName));
```