### PR TITLE
Support configure code-only configuration for StackExchange.Redis bus

### DIFF
--- a/bus/EasyCaching.Bus.Redis/Configurations/RedisBusOptions.cs
+++ b/bus/EasyCaching.Bus.Redis/Configurations/RedisBusOptions.cs
@@ -1,6 +1,7 @@
 ﻿namespace EasyCaching.Bus.Redis
 {
     using EasyCaching.Core.Configurations;
+    using StackExchange.Redis;
 
     /// <summary>
     /// Redis bus options.
@@ -17,5 +18,10 @@
         /// Gets or sets the serializer name that should be use in this bus.
         /// </summary>
         public string SerializerName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Redis database ConfigurationOptions will use.
+        /// </summary>
+        public ConfigurationOptions ConfigurationOptions { get; set; }
     }
 }

--- a/bus/EasyCaching.Bus.Redis/Configurations/RedisSubscriberProvider.cs
+++ b/bus/EasyCaching.Bus.Redis/Configurations/RedisSubscriberProvider.cs
@@ -49,7 +49,7 @@
         private ConnectionMultiplexer CreateConnectionMultiplexer()
         {
             if (_options.ConfigurationOptions != null)
-                return ConnectionMultiplexer.Connect(_options.ConfigurationOptions.ToString());
+                return ConnectionMultiplexer.Connect(_options.ConfigurationOptions);
 
             if (string.IsNullOrWhiteSpace(_options.Configuration))
             {
@@ -70,7 +70,7 @@
                     configurationOptions.EndPoints.Add(endpoint.Host, endpoint.Port);
                 }
 
-                return ConnectionMultiplexer.Connect(configurationOptions.ToString());
+                return ConnectionMultiplexer.Connect(configurationOptions);
             }
             else
             {

--- a/bus/EasyCaching.Bus.Redis/Configurations/RedisSubscriberProvider.cs
+++ b/bus/EasyCaching.Bus.Redis/Configurations/RedisSubscriberProvider.cs
@@ -48,6 +48,9 @@
         /// <returns>The connection multiplexer.</returns>
         private ConnectionMultiplexer CreateConnectionMultiplexer()
         {
+            if (_options.ConfigurationOptions != null)
+                return ConnectionMultiplexer.Connect(_options.ConfigurationOptions.ToString());
+
             if (string.IsNullOrWhiteSpace(_options.Configuration))
             {
                 var configurationOptions = new ConfigurationOptions


### PR DESCRIPTION
### Usage:
```C#
var redisConfig = ConfigurationOptions.Parse("127.0.0.1:6379");
redisConfig.DefaultDatabase = 6;
services.AddEasyCaching(option =>
{
    option.WithRedisBus(config =>
    {
        config.ConfigurationOptions = redisConfig;
        config.SerializerName = "myredis";
    });
});
```