### PR TITLE
fix: Using IConfiguration for WithRedisBus configuration cause DefaultRedisBus throw "Sequence contains no matching element" exception

### DIFF
--- a/build/releasenotes.props
+++ b/build/releasenotes.props
@@ -45,6 +45,7 @@
 		<EasyCachingRedisBusPackageNotes>
 			1. Support code configuration for StackExchange.Redis.
 			2. Support async version of subscribe.
+			3. fix: Using IConfiguration for WithRedisBus configuration cause DefaultRedisBus throw "Sequence contains no matching element" exception
 		</EasyCachingRedisBusPackageNotes>
 		<EasyCachingRabbitBusPackageNotes>
 			1. Support async version of subscribe.

--- a/build/version.props
+++ b/build/version.props
@@ -13,7 +13,7 @@
 		<EasyCachingMessagePackPackageVersion>1.9.0</EasyCachingMessagePackPackageVersion>
 		<EasyCachingProtobufPackageVersion>1.9.0</EasyCachingProtobufPackageVersion>
 		<EasyCachingCSRedisPackageVersion>1.9.0</EasyCachingCSRedisPackageVersion>
-		<EasyCachingRedisBusPackageVersion>1.9.0</EasyCachingRedisBusPackageVersion>
+		<EasyCachingRedisBusPackageVersion>1.9.1</EasyCachingRedisBusPackageVersion>
 		<EasyCachingCSRedisBusPackageVersion>1.9.0</EasyCachingCSRedisBusPackageVersion>
 		<EasyCachingRabbitBusPackageVersion>1.9.0</EasyCachingRabbitBusPackageVersion>
 		<EasyCachingKafkaBusPackageVersion>1.9.0</EasyCachingKafkaBusPackageVersion>

--- a/bus/EasyCaching.Bus.Redis/Configurations/EasyCachingOptionsExtensions.cs
+++ b/bus/EasyCaching.Bus.Redis/Configurations/EasyCachingOptionsExtensions.cs
@@ -58,6 +58,7 @@
                 x.Username = redisOptions.Username;
                 x.Password = redisOptions.Password;
                 x.SslHost = redisOptions.SslHost;
+                x.SerializerName = redisOptions.SerializerName;
 
                 foreach (var item in redisOptions.Endpoints) x.Endpoints.Add(item);
             }


### PR DESCRIPTION
Fixes #477 


