### PR TITLE
FEAT: add 2nd overload for AddEasyCaching() to support IServiceProvider for setupActions

### DIFF
--- a/src/EasyCaching.Core/Configurations/EasyCachingServiceCollectionExtensions.cs
+++ b/src/EasyCaching.Core/Configurations/EasyCachingServiceCollectionExtensions.cs
@@ -10,7 +10,7 @@
     public static class EasyCachingServiceCollectionExtensions
     {
         /// <summary>
-        /// Adds the easycaching.
+        /// Adds the EasyCaching.
         /// </summary>
         /// <returns>The easy caching.</returns>
         /// <param name="services">Services.</param>
@@ -27,6 +27,39 @@
                 serviceExtension.AddServices(services);
             }
             services.AddSingleton(options);
+
+            return services;
+        }
+        
+        /// <summary>
+        /// Adds the EasyCaching.
+        /// </summary>
+        /// <returns>The easy caching.</returns>
+        /// <param name="services">Services.</param>
+        /// <param name="setupAction">Setup action.</param>
+        public static IServiceCollection AddEasyCaching(this IServiceCollection services, Action<IServiceProvider, EasyCachingOptions> setupAction)
+        {
+            ArgumentCheck.NotNull(setupAction, nameof(setupAction));
+
+            // Options
+            services.AddSingleton(sp =>
+            {
+                var options = new EasyCachingOptions();
+                setupAction(sp, options);
+                return options;
+            });
+
+            // Extension services
+            services.AddSingleton(sp =>
+            {
+                var options = sp.GetRequiredService<EasyCachingOptions>();
+                foreach (var serviceExtension in options.Extensions)
+                {
+                    serviceExtension.AddServices(services);
+                }
+                
+                return options;
+            });
 
             return services;
         }


### PR DESCRIPTION
Added 2nd overload for AddEasyCaching() extension method to support IServiceProvider for setupActions.

cc: @catcherwong 