### PR TITLE
chore: fix release wf error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           uses: actions/download-artifact@v3
           with:
             name: nugetpkgs
+            path: nugetpkgs
         - name: list nugetpkgs
           run: ls nugetpkgs
         - name: Release

--- a/.github/workflows/release_stable.yml
+++ b/.github/workflows/release_stable.yml
@@ -36,6 +36,7 @@ jobs:
           uses: actions/download-artifact@v3
           with:
             name: nugetpkgs
+            path: nugetpkgs
         - name: list nugetpkgs
           run: ls nugetpkgs
         - name: Release


### PR DESCRIPTION
After pr was merged, github action cannot release packages.

https://github.com/dotnetcore/EasyCaching/actions/runs/6502527378/job/17661711292

`download-artifact@v3` should specify the path.

/cc @Memoyu 