### PR TITLE
add ClientProvidedName on publisher connection

### DIFF
--- a/bus/EasyCaching.Bus.RabbitMQ/Configurations/ModelPooledObjectPolicy.cs
+++ b/bus/EasyCaching.Bus.RabbitMQ/Configurations/ModelPooledObjectPolicy.cs
@@ -28,7 +28,8 @@
                 VirtualHost = _options.VirtualHost,
                 RequestedConnectionTimeout = System.TimeSpan.FromMilliseconds(_options.RequestedConnectionTimeout),
                 SocketReadTimeout = System.TimeSpan.FromMilliseconds(_options.SocketReadTimeout),
-                SocketWriteTimeout = System.TimeSpan.FromMilliseconds(_options.SocketWriteTimeout)
+                SocketWriteTimeout = System.TimeSpan.FromMilliseconds(_options.SocketWriteTimeout),
+                ClientProvidedName = _options.ClientProvidedName,
             };
 
             return factory.CreateConnection();


### PR DESCRIPTION
Add ClientProvidedName on publisher connection also. 

This can help identify issues with connections/channels/etc by making it much easier to map a connection to an application instance.