### PR TITLE
Support FasterKv options

### DIFF
--- a/src/EasyCaching.FasterKv/Configurations/FasterKvCachingOptions.cs
+++ b/src/EasyCaching.FasterKv/Configurations/FasterKvCachingOptions.cs
@@ -47,7 +47,21 @@ namespace EasyCaching.FasterKv.Configurations
 #else
             Path.Combine(Environment.CurrentDirectory, $"EasyCaching-FasterKv-{System.Diagnostics.Process.GetCurrentProcess().Id}");
 #endif
-            
+        
+        /// <summary>
+        /// Preallocate file
+        /// </summary>
+        public bool PreallocateFile { get; set; } = false;
+    
+        /// <summary>
+        /// Delete file on close
+        /// </summary>
+        public bool DeleteFileOnClose { get; set; } = true;
+    
+        /// <summary>
+        /// Try recover latest
+        /// </summary>
+        public bool TryRecoverLatest { get; set; } = false;
         
         /// <summary>
         /// Set Custom Store
@@ -59,8 +73,8 @@ namespace EasyCaching.FasterKv.Configurations
             return new LogSettings
             {
                 LogDevice = Devices.CreateLogDevice(Path.Combine(LogPath, name),
-                    preallocateFile: true,
-                    deleteOnClose: true),
+                    preallocateFile: PreallocateFile,
+                    deleteOnClose: DeleteFileOnClose),
                 PageSizeBits = PageSizeBit,
                 MemorySizeBits = MemorySizeBit,
                 ReadCacheSettings = new ReadCacheSettings

--- a/src/EasyCaching.FasterKv/Configurations/FasterKvCachingOptionsExtensions.cs
+++ b/src/EasyCaching.FasterKv/Configurations/FasterKvCachingOptionsExtensions.cs
@@ -60,6 +60,9 @@ public static class FasterKvCachingOptionsExtensions
                 x.ReadCacheMemorySizeBit = fasterKvOptions.ReadCacheMemorySizeBit;
                 x.ReadCachePageSizeBit = fasterKvOptions.ReadCachePageSizeBit;
                 x.LogPath = fasterKvOptions.LogPath;
+                x.PreallocateFile = fasterKvOptions.PreallocateFile;
+                x.DeleteFileOnClose = fasterKvOptions.DeleteFileOnClose;
+                x.TryRecoverLatest = fasterKvOptions.TryRecoverLatest;
             }
 
             options.RegisterExtension(new FasterKvOptionsExtension(name, Configure));


### PR DESCRIPTION
I received feedback from users utilizing EasyCaching, indicating a need to preserve cached data after the process terminates. In response to this, I have made these options available in this commit.

1. pre allocate file
2. delete file on close
3. try recover latest