### PR TITLE
add PublishingChannelsPoolSize option

### DIFF
--- a/bus/EasyCaching.Bus.RabbitMQStream/DefaultRabbitMQStreamBus.cs
+++ b/bus/EasyCaching.Bus.RabbitMQStream/DefaultRabbitMQStreamBus.cs
@@ -97,6 +97,11 @@ namespace EasyCaching.Bus.RabbitMQ
                 };
 
                 var provider = new DefaultObjectPoolProvider();
+                
+                if (_options.PublishingChannelsPoolSize.HasValue) 
+                {
+                    provider.MaximumRetained = _options.PublishingChannelsPoolSize.Value;
+                }
 
                 _pubChannelPool = provider.Create(objectPolicy);
 

--- a/src/EasyCaching.Core/Configurations/BaseRabbitMQOptions.cs
+++ b/src/EasyCaching.Core/Configurations/BaseRabbitMQOptions.cs
@@ -56,5 +56,10 @@
         /// Gets or sets the client-provided name for the rabbit connection. Default null (handled by rabbit client)
         /// </summary>
         public string ClientProvidedName { get; set; }
+        
+        /// <summary>
+        /// Sets the Pool size for the publishing channels, if null the default is used (default = cpu core count x 2)
+        /// </summary>
+        public int? PublishingChannelsPoolSize { get; set; } = null;
     }
 }


### PR DESCRIPTION
Justification:
When running on containerized environments the default pool size is set to the 2x the host CPU count (which for datacenter machines can be up to 256 cores). We provide a way to override this setting.