### PR TITLE
Clear lock on exception in disk cache GetAsync, ignore _Lock keys on Init()

### DIFF
--- a/src/EasyCaching.Disk/DefaultDiskCachingProvider.Async.cs
+++ b/src/EasyCaching.Disk/DefaultDiskCachingProvider.Async.cs
@@ -10,7 +10,7 @@
     using Microsoft.Extensions.Logging;
 
     public partial class DefaultDiskCachingProvider : EasyCachingAbstractProvider
-    {   
+    {
         public override async Task<bool> BaseExistsAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
@@ -38,7 +38,7 @@
             _cacheKeysMap.Clear();
 
             return Task.CompletedTask;
-        }            
+        }
 
         public override async Task<IDictionary<string, CacheValue<T>>> BaseGetAllAsync<T>(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
@@ -151,7 +151,7 @@
                 return CacheValue<T>.NoValue;
               }
             }
-            catch (Exception ex)
+            catch
             {
               //remove mutex key
               _cacheKeysMap.TryRemove($"{cacheKey}_Lock", out _);
@@ -248,7 +248,7 @@
                 return CacheValue<T>.NoValue;
             }
         }
-            
+
         public override async Task<IDictionary<string, CacheValue<T>>> BaseGetByPrefixAsync<T>(string prefix, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(prefix, nameof(prefix));
@@ -295,7 +295,7 @@
 
             return dict;
         }
-             
+
         public override async Task<TimeSpan> BaseGetExpirationAsync(string cacheKey, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
@@ -310,8 +310,8 @@
             var cached = await GetDiskCacheValueAsync(path, cancellationToken);
 
             return DateTimeOffset.FromUnixTimeMilliseconds((long)cached.Expiration).Subtract(DateTimeOffset.UtcNow);
-        }             
-              
+        }
+
         public override Task BaseRemoveAllAsync(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNullAndCountGTZero(cacheKeys, nameof(cacheKeys));
@@ -382,7 +382,7 @@
 
             var searchPattern = this.ProcessSearchKeyPattern(pattern);
             var searchKey = this.HandleSearchKeyPattern(pattern);
-            
+
             var list = _cacheKeysMap.Where(pair => FilterByPattern(pair.Key,searchKey, searchPattern)).Select(x => x.Key).ToList();
 
             foreach (var item in list)
@@ -397,7 +397,7 @@
 
             return Task.CompletedTask;
         }
-        
+
         public override async Task BaseSetAllAsync<T>(IDictionary<string, T> values, TimeSpan expiration, CancellationToken cancellationToken = default)
         {
             ArgumentCheck.NotNegativeOrZero(expiration, nameof(expiration));
@@ -471,7 +471,7 @@
                 return true;
             }
         }
-               
+
         private async Task<DiskCacheValue> GetDiskCacheValueAsync(string path, CancellationToken cancellationToken = default)
         {
             using (FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))

--- a/src/EasyCaching.Disk/DefaultDiskCachingProvider.Async.cs
+++ b/src/EasyCaching.Disk/DefaultDiskCachingProvider.Async.cs
@@ -133,20 +133,29 @@
                 return await GetAsync(cacheKey, dataRetriever, expiration, cancellationToken);
             }
 
-            var res = await dataRetriever();
-
-            if (res != null || _options.CacheNulls)
+            try
             {
+              var res = await dataRetriever();
+
+              if (res != null || _options.CacheNulls)
+              {
                 await SetAsync(cacheKey, res, expiration, cancellationToken);
                 //remove mutex key
                 _cacheKeysMap.TryRemove($"{cacheKey}_Lock", out _);
                 return new CacheValue<T>(res, true);
-            }
-            else
-            {
+              }
+              else
+              {
                 //remove mutex key
                 _cacheKeysMap.TryRemove($"{cacheKey}_Lock", out _);
                 return CacheValue<T>.NoValue;
+              }
+            }
+            catch (Exception ex)
+            {
+              //remove mutex key
+              _cacheKeysMap.TryRemove($"{cacheKey}_Lock", out _);
+              throw;
             }
         }
 

--- a/src/EasyCaching.Disk/DefaultDiskCachingProvider.cs
+++ b/src/EasyCaching.Disk/DefaultDiskCachingProvider.cs
@@ -270,7 +270,7 @@
                 return CacheValue<T>.NoValue;
               }
             }
-            catch (Exception ex)
+            catch
             {
               // remove mutex key
               _cacheKeysMap.TryRemove($"{cacheKey}_Lock", out _);

--- a/src/EasyCaching.Disk/DefaultDiskCachingProvider.cs
+++ b/src/EasyCaching.Disk/DefaultDiskCachingProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace EasyCaching.Disk
+namespace EasyCaching.Disk
 {
     using EasyCaching.Core;
     using EasyCaching.Core.DistributedLock;
@@ -171,9 +171,12 @@
                             string line;
                             while ((line = reader.ReadLine()) != null)
                             {
+                              if (!line.EndsWith("_Lock", StringComparison.Ordinal))
+                              {
                                 _cacheKeysMap.TryAdd(line, GetMd5Str(line));
                             }
                         }
+                    }
                     }
 
                     break;

--- a/src/EasyCaching.Disk/DefaultDiskCachingProvider.cs
+++ b/src/EasyCaching.Disk/DefaultDiskCachingProvider.cs
@@ -1,4 +1,4 @@
-namespace EasyCaching.Disk
+﻿namespace EasyCaching.Disk
 {
     using EasyCaching.Core;
     using EasyCaching.Core.DistributedLock;
@@ -174,9 +174,9 @@ namespace EasyCaching.Disk
                               if (!line.EndsWith("_Lock", StringComparison.Ordinal))
                               {
                                 _cacheKeysMap.TryAdd(line, GetMd5Str(line));
+                              }
                             }
                         }
-                    }
                     }
 
                     break;
@@ -244,28 +244,37 @@ namespace EasyCaching.Disk
             if (_options.EnableLogging)
                 _logger?.LogInformation($"Cache Missed : cachekey = {cacheKey}");
 
-            // TODO: how to add mutex key here
-            if (!_cacheKeysMap.TryAdd($"{cacheKey}_Lock", "1"))
+            try
             {
+              // TODO: how to add mutex key here
+              if (!_cacheKeysMap.TryAdd($"{cacheKey}_Lock", "1"))
+              {
                 System.Threading.Thread.Sleep(_options.SleepMs);
                 return Get(cacheKey, dataRetriever, expiration);
-            }
+              }
 
-            var res = dataRetriever();
+              var res = dataRetriever();
 
-            if (res != null || _options.CacheNulls)
-            {
+              if (res != null || _options.CacheNulls)
+              {
                 Set(cacheKey, res, expiration);
                 // remove mutex key
                 _cacheKeysMap.TryRemove($"{cacheKey}_Lock", out _);
 
                 return new CacheValue<T>(res, true);
-            }
-            else
-            {
+              }
+              else
+              {
                 // remove mutex key
                 _cacheKeysMap.TryRemove($"{cacheKey}_Lock", out _);
                 return CacheValue<T>.NoValue;
+              }
+            }
+            catch (Exception ex)
+            {
+              // remove mutex key
+              _cacheKeysMap.TryRemove($"{cacheKey}_Lock", out _);
+              throw;
             }
         }
 


### PR DESCRIPTION
Fixes #523

If the implementation's dataRetriever() throws an exception, the relevant cache key stays locked and will never recover. This removes the lock if there is an exception.

Also when the disk cache provider is initialized, added ignoring existing _Lock keys for situations where the app crashed or was restarted while the Lock was saved to the keys.dat.

