### PR TITLE
#528 optimise dependencies for net 6

### DIFF
--- a/interceptor/EasyCaching.Interceptor.Castle/EasyCaching.Interceptor.Castle.csproj
+++ b/interceptor/EasyCaching.Interceptor.Castle/EasyCaching.Interceptor.Castle.csproj
@@ -39,6 +39,8 @@
 		<PackageReference Include="Autofac.Extras.DynamicProxy" Version="6.0.1" />
 		<PackageReference Include="Autofac" Version="6.3.0" />
 		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)'== 'netStandard2.0'">
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 	</ItemGroup>
 </Project>

--- a/serialization/EasyCaching.Serialization.SystemTextJson/EasyCaching.Serialization.SystemTextJson.csproj
+++ b/serialization/EasyCaching.Serialization.SystemTextJson/EasyCaching.Serialization.SystemTextJson.csproj
@@ -30,7 +30,7 @@
 		<None Include="../../media/nuget-icon.png" Pack="true" Visible="false" PackagePath="" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)'== 'netStandard2.0'">
 		<PackageReference Include="System.Text.Json" Version="6.0.3" />
 	</ItemGroup>
 

--- a/src/EasyCaching.Core/EasyCaching.Core.csproj
+++ b/src/EasyCaching.Core/EasyCaching.Core.csproj
@@ -42,7 +42,6 @@
 		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
 	</ItemGroup>
-	
+
 </Project>

--- a/src/EasyCaching.SQLite/EasyCaching.SQLite.csproj
+++ b/src/EasyCaching.SQLite/EasyCaching.SQLite.csproj
@@ -37,15 +37,15 @@
 	<ItemGroup>
 		<PackageReference Include="Dapper" Version="2.0.30" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Microsoft.Data.SQLite" Version="3.1.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
 		<PackageReference Include="Microsoft.Data.SQLite" Version="6.0.0" />
 	</ItemGroup>
-	
+
 </Project>


### PR DESCRIPTION
Removes the below packages when targetting net 6 as the framework can provide them:

- Microsoft.CSharp
- System.Diagnostics.DiagnosticSourc
- System.Text.Json

closes #528 