### PR TITLE
fix File.Create on Init() not disposed

### DIFF
--- a/src/EasyCaching.Disk/DefaultDiskCachingProvider.cs
+++ b/src/EasyCaching.Disk/DefaultDiskCachingProvider.cs
@@ -115,7 +115,7 @@
 
             if (!File.Exists(path))
             {
-                File.Create(path);
+                using (File.Create(path)) {}
             }
 
             InitCacheKey();


### PR DESCRIPTION
I'm not sure why this happens and seems to happen more frequently during debugging but sometimes creating the FileStream in InitCacheKey() for the Disk cache provider will fail with "the file is use" because File.Create(path) returns a FileStream that is not closed/disposed.
https://github.com/InspireHUB/EasyCaching/blob/2eb92279d65a3a5f1c9fad1cb4f98344f7c98baa/src/EasyCaching.Disk/DefaultDiskCachingProvider.cs#L167