### PR TITLE
Bugfix #537 issue and Correct namespace and StringEncoding default value

### DIFF
--- a/serialization/EasyCaching.Serialization.MemoryPack/Configurations/EasyCachingMemPackSerializerOptions.cs
+++ b/serialization/EasyCaching.Serialization.MemoryPack/Configurations/EasyCachingMemPackSerializerOptions.cs
@@ -7,7 +7,11 @@ namespace EasyCaching.Serialization.MemoryPack;
 /// </summary>
 public record EasyCachingMemPackSerializerOptions
 {
-    public StringEncoding StringEncoding { set; get; }
+    /// <summary>
+    /// Gets or sets the string encoding. (Defaults to <see cref="StringEncoding.Utf8"/>)
+    /// </summary>
+    /// <value>
+    /// The string encoding.
+    /// </value>
+    public StringEncoding StringEncoding { set; get; } = StringEncoding.Utf8;
 }
-
-

--- a/serialization/EasyCaching.Serialization.MemoryPack/Configurations/EasyCachingOptionsExtensions.cs
+++ b/serialization/EasyCaching.Serialization.MemoryPack/Configurations/EasyCachingOptionsExtensions.cs
@@ -1,8 +1,7 @@
-﻿using MemoryPack;
-using EasyCaching.Core.Configurations;
-using EasyCaching.Serialization.Json;
+﻿using EasyCaching.Core.Configurations;
+using EasyCaching.Serialization.MemoryPack;
 
-namespace EasyCaching.Serialization.MemoryPack;
+namespace Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
 /// Easy caching options extensions.
@@ -13,7 +12,7 @@ public static class EasyCachingOptionsExtensions
     /// Withs the memory pack serializer.
     /// </summary>
     /// <param name="options">Options.</param>
-    /// <param name="name">The name of this serializer instance.</param>        
+    /// <param name="name">The name of this serializer instance.</param>
     public static EasyCachingOptions WithMemoryPack(this EasyCachingOptions options, string name = "mempack")
     {
         options.RegisterExtension(new MemoryPackOptionsExtension(name, null));
@@ -23,10 +22,10 @@ public static class EasyCachingOptionsExtensions
 
     /// <summary>
     /// Withs the memory pack serializer.
-    /// </summary>        
+    /// </summary>
     /// <param name="options">Options.</param>
     /// <param name="serializerOptions">Configure serializer settings.</param>
-    /// <param name="name">The name of this serializer instance.</param>     
+    /// <param name="name">The name of this serializer instance.</param>
     public static EasyCachingOptions WithMemoryPack(this EasyCachingOptions options, Action<EasyCachingMemPackSerializerOptions> serializerOptions, string name)
     {
         options.RegisterExtension(new MemoryPackOptionsExtension(name, serializerOptions));

--- a/serialization/EasyCaching.Serialization.MemoryPack/Configurations/MemoryPackOptionsExtension.cs
+++ b/serialization/EasyCaching.Serialization.MemoryPack/Configurations/MemoryPackOptionsExtension.cs
@@ -1,11 +1,9 @@
-namespace EasyCaching.Serialization.Json;
-
-using System;
 using EasyCaching.Core.Configurations;
 using EasyCaching.Core.Serialization;
-using EasyCaching.Serialization.MemoryPack;
-using global::MemoryPack;
+using MemoryPack;
 using Microsoft.Extensions.DependencyInjection;
+
+namespace EasyCaching.Serialization.MemoryPack;
 
 /// <summary>
 /// MemoryPack options extension.
@@ -29,8 +27,8 @@ internal sealed class MemoryPackOptionsExtension : IEasyCachingOptionsExtension
     /// <param name="configure">Configure.</param>
     public MemoryPackOptionsExtension(string name, Action<EasyCachingMemPackSerializerOptions> configure)
     {
-        this._name = name;
-        this._configure = configure;
+        _name = name;
+        _configure = configure;
     }
 
     /// <summary>
@@ -44,11 +42,16 @@ internal sealed class MemoryPackOptionsExtension : IEasyCachingOptionsExtension
         services.AddOptions();
         services.Configure(_name, configure);
 
-        services.AddSingleton<IEasyCachingSerializer, DefaultMemoryPackSerializer>(x =>
+        services.AddSingleton<IEasyCachingSerializer, DefaultMemoryPackSerializer>(services =>
         {
-            var optionsMon = x.GetRequiredService<Microsoft.Extensions.Options.IOptionsMonitor<EasyCachingMemPackSerializerOptions>>();
+            var optionsMon = services.GetRequiredService<Microsoft.Extensions.Options.IOptionsMonitor<EasyCachingMemPackSerializerOptions>>();
             var easyCachingOptions = optionsMon.Get(_name);
-            var options = new MemoryPackSerializerOptions { StringEncoding = easyCachingOptions.StringEncoding };
+
+            var options = MemoryPackSerializerOptions.Default;
+            typeof(MemoryPackSerializerOptions)
+                .GetProperty(nameof(MemoryPackSerializerOptions.StringEncoding))
+                .SetValue(options, easyCachingOptions.StringEncoding);
+
             return new DefaultMemoryPackSerializer(_name, options);
         });
     }


### PR DESCRIPTION
- **Bugfix issue** #537

- **Correct namespace**
This package has nothing to do with `EasyCaching.Serialization.Json` 
So this namespace is wrong in this [code](https://github.com/dotnetcore/EasyCaching/blob/c52c8f65591ece1e9821dcf77d28cc307bfa96b9/serialization/EasyCaching.Serialization.MemoryPack/Configurations/MemoryPackOptionsExtension.cs#L1C1-L1C42). (now is fixed by this PR)

- **StringEncoding default value**
According to the [MemoryPack's code](https://github.com/Cysharp/MemoryPack/blob/4b1e3f889fbc8bae6e700bc148f6dbba0a4b7170/src/MemoryPack.Core/MemoryPackSerializerOptions.cs#L6) the default value for this should be `StringEncoding.Utf8` but the [current implementation](https://github.com/dotnetcore/EasyCaching/blob/c52c8f65591ece1e9821dcf77d28cc307bfa96b9/serialization/EasyCaching.Serialization.MemoryPack/Configurations/EasyCachingMemPackSerializerOptions.cs#L10) defaults to `Utf16` because no value has been set and the first value of that enum is `Utf16`. (now is fixed by this PR)
