### PR TITLE
Fix wrong type name serialization due to the plus sign '+' is escaped.

### DIFF
--- a/test/EasyCaching.UnitTests/SerializerTests/SystemTestJsonSerializerTest.cs
+++ b/test/EasyCaching.UnitTests/SerializerTests/SystemTestJsonSerializerTest.cs
@@ -59,7 +59,7 @@ namespace EasyCaching.UnitTests.SerializerTests
             var serializer = new DefaultJsonSerializer("json", new JsonSerializerOptions
             {
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-            }) ;
+            });
 
             Employee joe = new Employee { Name = "Joe User" };
 
@@ -67,6 +67,20 @@ namespace EasyCaching.UnitTests.SerializerTests
             var joe_obj = serializer.Deserialize<Employee>(joe_byte);
 
             Assert.Null(joe.Manager);
+        }
+
+        [Fact]
+        public void SerializeObject_NestedClass_Test_Should_Succeed()
+        {
+            var serializer = new DefaultJsonSerializer("json", new JsonSerializerOptions());
+
+            Employee joe = new Employee { Name = "Joe User" };
+
+            var joe_byte = serializer.SerializeObject(joe);
+            var joe_obj = serializer.DeserializeObject(joe_byte);
+
+            Assert.IsType<Employee>(joe_obj);
+            Assert.Equal(joe.Name, ((Employee)joe_obj).Name);
         }
     }
 }


### PR DESCRIPTION
#### What Changed
- Use `JavaScriptEncoder.UnsafeRelaxedJsonEscaping` for Utf8JsonWriter in `DefaultJsonSerializer`

#### Why This Change
- When default encoder is used, the '+' in a type name will be escaped to \u002B in the method `SerializeObject`, which will lead to an error when trying to `GetType` by type name in the method `DeserializeObject`.
- Using JavaScriptEncoder.UnsafeRelaxedJsonEscaping can avoid the escape.
- See related issue on https://github.com/dotnet/runtime/issues/35281