### PR TITLE
use SortedSetLength for zcount

### DIFF
--- a/src/EasyCaching.Redis/DefaultRedisCachingProvider.SortedSet.cs
+++ b/src/EasyCaching.Redis/DefaultRedisCachingProvider.SortedSet.cs
@@ -38,7 +38,7 @@
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
-            var len = _cache.SortedSetLengthByValue(cacheKey, min, max);
+            var len = _cache.SortedSetLength(cacheKey, min, max);
             return len;
         }
 
@@ -166,7 +166,7 @@
         {
             ArgumentCheck.NotNullOrWhiteSpace(cacheKey, nameof(cacheKey));
 
-            var len = await _cache.SortedSetLengthByValueAsync(cacheKey, min, max);
+            var len = await _cache.SortedSetLengthAsync(cacheKey, min, max);
             return len;
         }
 


### PR DESCRIPTION
### What Changed
- Use `SortedSetLength` for `ZCount`
- Use `SortedSetLengthAsync` for `ZCountAsync`

### Why This Change

The current used method `SortedSetLengthByValue` is actually used for `ZLexCount` not for `ZCount`.
See related issue on https://github.com/StackExchange/StackExchange.Redis/issues/1034